### PR TITLE
Add scry command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,116 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+---
+version: 2
+
+before:
+  hooks:
+    - mise run generate
+    - mise run completions
+    - mise run manpages
+    # - mise run release_notes {{ .RawVersion }}
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - "386"
+      - amd64
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: "386"
+    ldflags:
+      - -s -w -X {{.ModulePath}}/cmd/version/version.version={{.Version}}
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+upx:
+  - goos: [linux]
+    enabled: "{{ .IsRelease }}"
+    compress: best
+
+archives:
+  - formats: [ 'tgz' ]
+    name_template: >-
+      {{ .ProjectName }}-
+      {{- .Version }}-
+      {{- .Os }}-
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch}}{{ end }}
+      {{- if .Arm }}_v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats: [ 'zip' ]
+    files:
+      - info:
+          owner: root
+          group: root
+          mode: 0644
+          mtime: "{{ .CommitDate }}"
+      - src: CHANGELOG*
+      - src: README*
+      - src: LICENSE*
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  version_template: "{{ .Version }}-snapshot"
+
+changelog:
+  disable: true
+
+release:
+  github:
+    owner: asphaltbuffet
+    name: wherehouse
+  prerelease: auto
+
+announce:
+  skip: true
+
+nfpms:
+  - file_name_template: "{{ .ConventionalFileName }}"
+    id: packages
+    homepage: https://github.com/asphaltbuffet/wherehouse
+    description: Keep track of all your things
+    maintainer: Ben Lechlitner <otherland@gmail.com>
+    license: MIT
+    vendor: asphaltbuffet
+    bindir: /usr/bin
+    section: utils
+    contents:
+      - src: ./completions/wherehouse.bash
+        dst: /usr/share/bash-completion/completions/wherehouse
+        file_info:
+          mode: 0644
+      - src: ./completions/wherehouse.fish
+        dst: /usr/share/fish/vendor_completions.d/wherehouse.fish
+        file_info:
+          mode: 0644
+      - src: ./completions/wherehouse.zsh
+        dst: /usr/share/zsh/vendor-completions/_wherehouse
+        file_info:
+          mode: 0644
+      - src: ./manpages/
+        dst: /usr/share/man/man1/
+        file_info:
+          mode: 0644
+      - src: ./LICENSE
+        dst: /usr/share/doc/wherehouse/copyright
+        file_info:
+          mode: 0644
+    formats:
+      - apk
+      - deb
+      - rpm
+    dependencies:
+      - golang
+    recommends:
+      - python3

--- a/README.md
+++ b/README.md
@@ -114,6 +114,47 @@ export PATH="$PATH:$HOME/.local/bin"  # add to ~/.bashrc or ~/.zshrc
 wherehouse --version
 ```
 
+### Nix
+
+**Standalone install** (no flake required):
+
+```bash
+nix profile install github:asphaltbuffet/wherehouse
+```
+
+**In a home-manager flake** — add as an input and load the bundled module:
+
+```nix
+# flake.nix
+{
+  inputs = {
+    nixpkgs.url      = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    home-manager.url = "github:nix-community/home-manager";
+    wherehouse.url   = "github:asphaltbuffet/wherehouse";
+    wherehouse.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { nixpkgs, home-manager, wherehouse, ... }: {
+    homeConfigurations."alice" = home-manager.lib.homeManagerConfiguration {
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      modules = [
+        wherehouse.homeManagerModules.default
+        {
+          programs.wherehouse.enable = true;
+          # see Configuration → Home Manager for all settings
+        }
+      ];
+    };
+  };
+}
+```
+
+**As a NixOS overlay** (adds `pkgs.wherehouse`):
+
+```nix
+nixpkgs.overlays = [ wherehouse.overlays.default ];
+```
+
 ### Using mise (Development)
 
 ```bash
@@ -388,62 +429,99 @@ wherehouse export > backup-$(date +%Y%m%d).json
 1. `--config <path>` flag
 2. `$WHEREHOUSE_CONFIG` environment variable
 3. `./wherehouse.toml` (current directory)
-4. `~/.config/wherehouse/config.toml` (default)
+4. `~/.config/wherehouse/wherehouse.toml` (default)
 
 **Data locations**:
-- Database: `~/.local/share/wherehouse/inventory.db`
-- Logs: `~/.local/share/wherehouse/logs/`
-- Cache: `~/.cache/wherehouse/`
+- Database: `~/.local/share/wherehouse/wherehouse.db`
 
 ### Configuration File
 
-**Example** (`~/.config/wherehouse/config.toml`):
+Create the default config with:
+
+```bash
+wherehouse config init
+```
+
+**Full example** (`~/.config/wherehouse/wherehouse.toml`):
 
 ```toml
-config_version = 1  # Required
-
-# Database location
-db_path = "~/.local/share/wherehouse/inventory.db"
+[database]
+# Path to SQLite database file. Supports ~ and $ENV_VARS.
+# Default: $XDG_DATA_HOME/wherehouse/wherehouse.db
+path = "~/.local/share/wherehouse/wherehouse.db"
 # Or network storage:
-# db_path = "/mnt/nas/shared/inventory.db"
+# path = "/mnt/nas/shared/wherehouse.db"
 
-# SQLite settings
-[sqlite]
-journal_mode = "WAL"         # Write-Ahead Logging (recommended)
-synchronous = "NORMAL"       # Balance safety vs performance
-busy_timeout = 30000         # 30 seconds (for network storage)
+[user]
+# Display name for event attribution. Empty = OS username.
+default_identity = ""
 
-# Display defaults
-[display]
-default_verbosity = "normal"  # quiet, normal, verbose
-default_grouping = "location" # location, project, status
-use_color = true              # colorized output
-use_icons = true              # emoji icons in output
+# Map OS usernames to display names.
+# os_username_map = { "jdoe" = "John Doe" }
+os_username_map = {}
 
-# User identity
-[users.alice]
-display_name = "Alice Smith"
-email = "alice@example.com"
+[output]
+# Default output format: "human" or "json"
+default_format = "human"
 
-[user_identity]
-# Map OS usernames to inventory users
-os_username_map = { "asmith" = "alice", "asmith-laptop" = "alice" }
+# Enable quiet mode by default
+quiet = false
 ```
+
+### Home Manager
+
+The flake ships a home-manager module at `homeManagerModules.default`. Enable it and
+configure `programs.wherehouse.settings` to generate `~/.config/wherehouse/wherehouse.toml`
+automatically — equivalent to running `wherehouse config init` and editing the result.
+
+```nix
+programs.wherehouse = {
+  enable = true;   # installs the package and enables the module
+
+  settings = {
+    database.path = "~/.local/share/wherehouse/wherehouse.db";
+
+    user = {
+      # Empty string means use the OS username.
+      defaultIdentity = "";
+
+      # Map OS usernames to display names.
+      osUsernameMap = {
+        jdoe   = "John Doe";
+        asmith = "Alice Smith";
+      };
+    };
+
+    output = {
+      defaultFormat = "human";  # "human" or "json"
+      quiet         = false;
+    };
+  };
+};
+```
+
+All `settings` fields are optional — omitting a field leaves the application default in
+effect. The config file is only written when at least one field is set.
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `settings.database.path` | string | XDG data dir | Path to SQLite database file |
+| `settings.user.defaultIdentity` | string | OS username | Display name for attribution |
+| `settings.user.osUsernameMap` | attrset | `{}` | Map OS usernames to display names |
+| `settings.output.defaultFormat` | `"human"` \| `"json"` | `"human"` | Default output format |
+| `settings.output.quiet` | bool | `false` | Suppress non-essential output |
 
 ### Environment Variables
 
 ```bash
 # Override database path
-export WHEREHOUSE_DB_PATH="/mnt/nas/inventory.db"
+export WHEREHOUSE_DATABASE_PATH="/mnt/nas/wherehouse.db"
 
 # Override config location
 export WHEREHOUSE_CONFIG="$HOME/projects/workshop/wherehouse.toml"
 
-# Set log level
-export WHEREHOUSE_LOG_LEVEL="debug"  # debug, info, warn, error
-
-# Disable color output
-export NO_COLOR=1
+# Override output format
+export WHEREHOUSE_OUTPUT_DEFAULT_FORMAT="json"
 ```
 
 ---

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/asphaltbuffet/wherehouse/cmd/loan"
 	"github.com/asphaltbuffet/wherehouse/cmd/lost"
 	"github.com/asphaltbuffet/wherehouse/cmd/move"
+	"github.com/asphaltbuffet/wherehouse/cmd/scry"
 	"github.com/asphaltbuffet/wherehouse/internal/config"
 	"github.com/asphaltbuffet/wherehouse/internal/version"
 )
@@ -60,6 +61,7 @@ Examples:
 	rootCmd.AddCommand(loan.GetLoanCmd())
 	rootCmd.AddCommand(lost.GetLostCmd())
 	rootCmd.AddCommand(move.GetMoveCmd())
+	rootCmd.AddCommand(scry.GetScryCmd())
 
 	return rootCmd
 }

--- a/cmd/scry/doc.go
+++ b/cmd/scry/doc.go
@@ -1,0 +1,2 @@
+// Package scry implements the "wherehouse scry" command
+package scry

--- a/cmd/scry/scry.go
+++ b/cmd/scry/scry.go
@@ -1,0 +1,294 @@
+package scry
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/goccy/go-json"
+	"github.com/spf13/cobra"
+
+	"github.com/asphaltbuffet/wherehouse/internal/cli"
+	"github.com/asphaltbuffet/wherehouse/internal/database"
+)
+
+// labelWidth is the fixed width of the label column (right-padded with spaces).
+const labelWidth = 26
+
+var scryCmd *cobra.Command
+
+// GetScryCmd returns the scry command, initializing it if necessary.
+func GetScryCmd() *cobra.Command {
+	if scryCmd != nil {
+		return scryCmd
+	}
+
+	scryCmd = &cobra.Command{
+		Use:   "scry <name>",
+		Short: "Suggest locations for a missing item based on history",
+		Long: `Suggest where to look for an item currently marked as missing.
+
+Scry analyzes event history to rank likely locations:
+  1. Home location: where the item was created or originally lived
+  2. Found here before: locations where the item was recovered (item.found events)
+  3. Used here temporarily: locations the item was taken to temporarily
+  4. Similar items: current locations of items with similar names
+
+The item must be in the Missing system location before scrying.
+
+Examples:
+  wherehouse scry "10mm socket"        # Suggest locations for a missing item
+  wherehouse scry missing:screwdriver  # Same, with explicit Missing: prefix`,
+		Args: cobra.ExactArgs(1),
+		RunE: runScry,
+	}
+
+	scryCmd.Flags().BoolP("verbose", "v", false, "Show full details (IDs, match distance)")
+	scryCmd.Flags().Bool("json", false, "Output as JSON")
+
+	return scryCmd
+}
+
+// runScry implements the scry command logic.
+func runScry(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	verbose, _ := cmd.Flags().GetBool("verbose")
+	jsonMode, _ := cmd.Flags().GetBool("json")
+
+	db, err := cli.OpenDatabase(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to open database: %w", err)
+	}
+	defer db.Close()
+
+	itemID, err := cli.ResolveItemSelector(ctx, db, args[0], "wherehouse scry")
+	if err != nil {
+		return err
+	}
+
+	item, err := db.GetItem(ctx, itemID)
+	if err != nil {
+		return fmt.Errorf("failed to get item: %w", err)
+	}
+
+	if err = validateItemIsMissing(ctx, db, item); err != nil {
+		return err
+	}
+
+	result, err := db.ScryItem(ctx, item)
+	if err != nil {
+		return fmt.Errorf("scry failed: %w", err)
+	}
+
+	if result.HomeLocation == nil &&
+		len(result.FoundLocations) == 0 &&
+		len(result.TempUseLocations) == 0 &&
+		len(result.SimilarItemLocations) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "No suggestions found for %q\n", item.DisplayName)
+		return nil
+	}
+
+	if jsonMode {
+		return outputJSON(cmd.OutOrStdout(), result)
+	}
+
+	outputHuman(cmd.OutOrStdout(), result, verbose)
+
+	return nil
+}
+
+// validateItemIsMissing checks that the item is in the Missing system location.
+// Returns specific errors for Borrowed and Loaned items.
+func validateItemIsMissing(ctx context.Context, db *database.Database, item *database.Item) error {
+	missingID, borrowedID, loanedID, err := db.GetSystemLocationIDs(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get system locations: %w", err)
+	}
+
+	switch item.LocationID {
+	case missingID:
+		return nil // OK
+	case borrowedID:
+		return fmt.Errorf("item %q is borrowed, not missing", item.DisplayName)
+	case loanedID:
+		return fmt.Errorf("item %q is loaned out, not missing", item.DisplayName)
+	default:
+		loc, locErr := db.GetLocation(ctx, item.LocationID)
+		locName := item.LocationID
+		if locErr == nil && loc != nil {
+			locName = loc.FullPathDisplay
+		}
+
+		return fmt.Errorf("item %q is not missing (currently at: %s)", item.DisplayName, locName)
+	}
+}
+
+// outputHuman formats scry results in human-readable format.
+func outputHuman(w io.Writer, result *database.ScryResult, verbose bool) {
+	fmt.Fprintf(w, "Scrying for: %s (MISSING)\n\n", result.DisplayName)
+
+	// Category 1: Home location (always shown, guaranteed non-nil)
+	if result.HomeLocation != nil {
+		printLabeledRow(w, "Home location:", result.HomeLocation.FullPathDisplay, "")
+	}
+
+	// Category 2: Previously found locations
+	printScoredCategory(w, "Found here before:", result.FoundLocations, verbose)
+
+	// Category 3: Temporary use locations
+	printScoredCategory(w, "Used here temporarily:", result.TempUseLocations, verbose)
+
+	// Category 4: Similar item locations
+	printSimilarItemCategory(w, "Where similar items are:", result.SimilarItemLocations, verbose)
+}
+
+// printScoredCategory prints a category of scored locations with occurrence counts.
+func printScoredCategory(w io.Writer, label string, locations []*database.ScoredLocation, verbose bool) {
+	for i, sl := range locations {
+		suffix := ""
+		if verbose {
+			if sl.Occurrences == 1 {
+				suffix = "  (1 time)"
+			} else {
+				suffix = fmt.Sprintf("  (%d times)", sl.Occurrences)
+			}
+		}
+
+		if i == 0 {
+			printLabeledRow(w, label, sl.Location.FullPathDisplay, suffix)
+		} else {
+			printContinuationRow(w, sl.Location.FullPathDisplay, suffix)
+		}
+	}
+}
+
+// printSimilarItemCategory prints the similar-item category, annotating each entry with the similar item name.
+func printSimilarItemCategory(w io.Writer, label string, locations []*database.ScoredLocation, verbose bool) {
+	for i, sl := range locations {
+		// Use SimilarItemDisplayName when available; fall back to SimilarItemName (canonical).
+		displayName := sl.SimilarItemDisplayName
+		if displayName == "" {
+			displayName = sl.SimilarItemName
+		}
+
+		var itemAnnotation string
+		if verbose {
+			itemAnnotation = fmt.Sprintf("  [%s, dist=%d]", displayName, sl.LevenshteinDistance)
+		} else {
+			itemAnnotation = fmt.Sprintf("  [%s]", displayName)
+		}
+
+		if i == 0 {
+			printLabeledRow(w, label, sl.Location.FullPathDisplay, itemAnnotation)
+		} else {
+			printContinuationRow(w, sl.Location.FullPathDisplay, itemAnnotation)
+		}
+	}
+}
+
+// printLabeledRow prints a row with a label in the first column and a value in the second.
+// suffix is appended directly after the value (no extra spacing).
+func printLabeledRow(w io.Writer, label, value, suffix string) {
+	fmt.Fprintf(w, "  %-*s%s%s\n", labelWidth, label, value, suffix)
+}
+
+// printContinuationRow prints a continuation row (no label, indented to value column).
+func printContinuationRow(w io.Writer, value, suffix string) {
+	// 2 leading spaces + labelWidth spaces = indent to value column
+	fmt.Fprintf(w, "  %-*s%s%s\n", labelWidth, "", value, suffix)
+}
+
+// JSON output structures.
+
+type jsonScryOutput struct {
+	ItemID               string            `json:"item_id"`
+	DisplayName          string            `json:"display_name"`
+	CanonicalName        string            `json:"canonical_name"`
+	HomeLocation         *jsonScryLocation `json:"home_location,omitempty"`
+	FoundLocations       []*jsonScoredLoc  `json:"found_locations"`
+	TempUseLocations     []*jsonScoredLoc  `json:"temp_use_locations"`
+	SimilarItemLocations []*jsonSimilarLoc `json:"similar_item_locations"`
+}
+
+type jsonScryLocation struct {
+	LocationID  string `json:"location_id"`
+	DisplayName string `json:"display_name"`
+	FullPath    string `json:"full_path"`
+}
+
+type jsonScoredLoc struct {
+	LocationID  string `json:"location_id"`
+	DisplayName string `json:"display_name"`
+	FullPath    string `json:"full_path"`
+	Occurrences int    `json:"occurrences"`
+}
+
+type jsonSimilarLoc struct {
+	LocationID             string `json:"location_id"`
+	DisplayName            string `json:"display_name"`
+	FullPath               string `json:"full_path"`
+	SimilarItem            string `json:"similar_item"`
+	SimilarItemDisplayName string `json:"similar_item_display_name"`
+	LevenshteinDistance    int    `json:"levenshtein_distance"`
+}
+
+// outputJSON formats scry results as JSON.
+func outputJSON(w io.Writer, result *database.ScryResult) error {
+	output := jsonScryOutput{
+		ItemID:               result.ItemID,
+		DisplayName:          result.DisplayName,
+		CanonicalName:        result.CanonicalName,
+		FoundLocations:       make([]*jsonScoredLoc, 0, len(result.FoundLocations)),
+		TempUseLocations:     make([]*jsonScoredLoc, 0, len(result.TempUseLocations)),
+		SimilarItemLocations: make([]*jsonSimilarLoc, 0, len(result.SimilarItemLocations)),
+	}
+
+	if result.HomeLocation != nil {
+		output.HomeLocation = &jsonScryLocation{
+			LocationID:  result.HomeLocation.LocationID,
+			DisplayName: result.HomeLocation.DisplayName,
+			FullPath:    result.HomeLocation.FullPathDisplay,
+		}
+	}
+
+	for _, sl := range result.FoundLocations {
+		output.FoundLocations = append(output.FoundLocations, &jsonScoredLoc{
+			LocationID:  sl.Location.LocationID,
+			DisplayName: sl.Location.DisplayName,
+			FullPath:    sl.Location.FullPathDisplay,
+			Occurrences: sl.Occurrences,
+		})
+	}
+
+	for _, sl := range result.TempUseLocations {
+		output.TempUseLocations = append(output.TempUseLocations, &jsonScoredLoc{
+			LocationID:  sl.Location.LocationID,
+			DisplayName: sl.Location.DisplayName,
+			FullPath:    sl.Location.FullPathDisplay,
+			Occurrences: sl.Occurrences,
+		})
+	}
+
+	for _, sl := range result.SimilarItemLocations {
+		// Use SimilarItemDisplayName when available; fall back to SimilarItemName (canonical).
+		displayName := sl.SimilarItemDisplayName
+		if displayName == "" {
+			displayName = sl.SimilarItemName
+		}
+
+		output.SimilarItemLocations = append(output.SimilarItemLocations, &jsonSimilarLoc{
+			LocationID:             sl.Location.LocationID,
+			DisplayName:            sl.Location.DisplayName,
+			FullPath:               sl.Location.FullPathDisplay,
+			SimilarItem:            sl.SimilarItemName,
+			SimilarItemDisplayName: displayName,
+			LevenshteinDistance:    sl.LevenshteinDistance,
+		})
+	}
+
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+
+	return encoder.Encode(output)
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -40,6 +40,7 @@ Primary daily workflows:
     - Rehome
     - Borrowed
 - Mark missing and found
+- Locate missing items (`scry`)
 - Associate items with projects
 
 ## ARCHITECTURAL PHILOSOPHY
@@ -357,6 +358,47 @@ Basement:Toolbox:"10mm socket wrench"
 ```
 
 Multiple matches return all.
+
+### scry
+
+```
+wherehouse scry <item>
+```
+
+Suggests where to look for a **missing** item. Read-only — does not mutate state.
+
+Accepts the same selectors as other commands (canonical name, UUID, `LOCATION:ITEM`).
+Only operates on items currently in the `Missing` system location; items in `Borrowed` or
+`Loaned` locations are rejected with a specific error message.
+
+Result categories (shown in confidence order):
+
+| Category | Source | Ranking |
+|---|---|---|
+| Home location | `temp_origin_location_id` projection field; falls back to `item.created` event location | Always present, shown first |
+| Found here before | `item.found` event log (`found_location_id`) | By occurrence count desc |
+| Used here temporarily | `item.moved` events with `move_type=temporary_use` (`to_location_id`) | By occurrence count desc |
+| Where similar items are | `items_current` projection; Levenshtein distance ≤ 3 on canonical names | By distance asc |
+
+Each location appears in at most one category (cross-category deduplication). System locations
+are excluded from all categories except "home location".
+
+Occurrence counts are used internally for ranking. In human output, counts are shown only with
+`--verbose`. JSON output always includes occurrence counts.
+
+**Human output:**
+
+```
+Scrying for: 10mm Socket Wrench (MISSING)
+
+  Home location:           Garage >> Toolbox
+  Found here before:       Workshop >> Pegboard
+                           Garage >> Shelf A
+  Used here temporarily:   Deck >> Project Bin
+  Where similar items are: Garage >> Toolbox  [9mm Socket Wrench]
+```
+
+**Flags:** `--verbose` / `-v`, `--json`
 
 ## CONFIGURATION (TOML via spf13/viper)
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,85 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gomod2nix": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770585520,
+        "narHash": "sha256-yBz9Ozd5Wb56i3e3cHZ8WcbzCQ9RlVaiW18qDYA/AzA=",
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "rev": "1201ddd1279c35497754f016ef33d5e060f3da8d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "gomod2nix": "gomod2nix",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,103 @@
+{
+  description = "wherehouse - Track your stuff";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    gomod2nix = {
+      url = "github:nix-community/gomod2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    gomod2nix,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [gomod2nix.overlays.default];
+        };
+        lib = pkgs.lib;
+        version =
+          if (self ? shortRev)
+          then self.shortRev
+          else "dev";
+      in {
+        packages.default = pkgs.buildGoApplication {
+          pname = "wherehouse";
+          inherit version;
+
+          src = lib.fileset.toSource {
+            root = ./.;
+            fileset = lib.fileset.unions [
+              ./go.mod
+              ./go.sum
+              ./gomod2nix.toml
+              (lib.fileset.fileFilter (file: lib.hasSuffix ".go" file.name) ./.)
+            ];
+          };
+
+          modules = ./gomod2nix.toml;
+
+          # Only build the main binary
+          subPackages = ["."];
+
+          ldflags = [
+            "-s"
+            "-w"
+            "-X github.com/asphaltbuffet/wherehouse/internal/version.Version=${version}"
+          ];
+
+          postInstall = ''
+            # Generate and install shell completions
+            installShellCompletion --cmd wherehouse \
+              --bash <($out/bin/wherehouse completion bash) \
+              --fish <($out/bin/wherehouse completion fish) \
+              --zsh <($out/bin/wherehouse completion zsh)
+
+            # Generate and install man pages
+            mkdir -p manpages
+            $out/bin/wherehouse man
+            mkdir -p $out/share/man/man1
+            for f in manpages/*.1; do
+              ${pkgs.gzip}/bin/gzip -c "$f" > "$out/share/man/man1/$(basename $f).gz"
+            done
+          '';
+
+          nativeBuildInputs = [pkgs.installShellFiles];
+
+          meta = with lib; {
+            description = "Keep track of your stuff";
+            homepage = "https://github.com/asphaltbuffet/wherehouse";
+            license = licenses.mit;
+            mainProgram = "wherehouse";
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            go
+            mise
+            gomod2nix.packages.${system}.default
+          ];
+
+          shellHook = ''
+            mise trust --all
+          '';
+        };
+      }
+    )
+    // {
+      overlays.default = final: prev: {
+        wherehouse = self.packages.${prev.system}.default;
+      };
+
+      homeManagerModules.default = import ./nix/home-manager.nix;
+    };
+}

--- a/internal/database/scry.go
+++ b/internal/database/scry.go
@@ -1,0 +1,488 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/agnivade/levenshtein"
+	"github.com/goccy/go-json"
+)
+
+// similarityThreshold is the maximum Levenshtein distance for "similar item" matching.
+// Lower = stricter. Defined here for tuning without interface changes.
+const similarityThreshold = 3
+
+// ScryResult contains ranked location suggestions for a missing item.
+type ScryResult struct {
+	ItemID        string
+	DisplayName   string
+	CanonicalName string
+
+	// HomeLocation is the most authoritative suggestion.
+	// Derived from temp_origin_location_id (projection) or item.created event location_id.
+	// This is NEVER nil because every item was created in some location.
+	HomeLocation *LocationInfo
+
+	// FoundLocations are locations where the item was physically found before (item.found events).
+	// Ordered by occurrence count descending, then most recent event_id descending.
+	// Occurrences field is populated; displayed only in verbose mode.
+	FoundLocations []*ScoredLocation
+
+	// TempUseLocations are locations the item was taken to temporarily (item.moved, move_type=temporary_use).
+	// Ordered by occurrence count descending, then most recent event_id descending.
+	// Occurrences field is populated; displayed only in verbose mode.
+	TempUseLocations []*ScoredLocation
+
+	// SimilarItemLocations are current locations of similarly-named items (Levenshtein distance <= 3).
+	// Ordered by distance ascending.
+	SimilarItemLocations []*ScoredLocation
+}
+
+// ScoredLocation is a location with ranking metadata.
+type ScoredLocation struct {
+	Location *LocationInfo
+
+	// Occurrences is the count of times this location appeared in history (categories 2 and 3).
+	// For similar-item results, this is 0.
+	// This field is used for ranking; displayed only in --verbose mode.
+	Occurrences int
+
+	// SimilarItemName is the canonical name of the similar item (category 4 only).
+	// Empty for history-based results.
+	SimilarItemName string
+
+	// SimilarItemDisplayName is the display name of the similar item (category 4 only).
+	// Empty for history-based results.
+	SimilarItemDisplayName string
+
+	// LevenshteinDistance is the distance from the target canonical name (category 4 only).
+	// 0 for history-based results.
+	LevenshteinDistance int
+}
+
+// ScryItem returns ranked location suggestions for a missing item.
+// item is the already-fetched Item record; callers should not fetch it again.
+// Returns a ScryResult with all suggestion categories populated.
+// The HomeLocation field is guaranteed non-nil if the item has any events (it always does).
+func (d *Database) ScryItem(ctx context.Context, item *Item) (*ScryResult, error) {
+	result := &ScryResult{
+		ItemID:        item.ItemID,
+		DisplayName:   item.DisplayName,
+		CanonicalName: item.CanonicalName,
+	}
+
+	// Category 1: Home location
+	homeLoc, err := d.scryHomeLocation(ctx, item)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine home location: %w", err)
+	}
+	result.HomeLocation = homeLoc
+
+	// Track seen location IDs to exclude from subsequent categories
+	seen := make(map[string]bool)
+	if homeLoc != nil {
+		seen[homeLoc.LocationID] = true
+	}
+
+	// Category 2: Previously found locations
+	foundLocs, err := d.scryFoundLocations(ctx, item.ItemID, seen)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get found locations: %w", err)
+	}
+	result.FoundLocations = foundLocs
+
+	// Category 3: Temporary use locations
+	tempLocs, err := d.scryTempUseLocations(ctx, item.ItemID, seen)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get temporary use locations: %w", err)
+	}
+	result.TempUseLocations = tempLocs
+
+	// Category 4: Similar item locations
+	similarLocs, err := d.scrySimilarItemLocations(ctx, item.CanonicalName, item.ItemID, seen)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get similar item locations: %w", err)
+	}
+	result.SimilarItemLocations = similarLocs
+
+	return result, nil
+}
+
+// scryHomeLocation returns the home location for an item.
+// Uses temp_origin_location_id from the projection if set; otherwise falls back
+// to the location_id from the item.created event.
+func (d *Database) scryHomeLocation(ctx context.Context, item *Item) (*LocationInfo, error) {
+	// If item is in temporary use, temp_origin_location_id is the home location
+	if item.TempOriginLocationID != nil {
+		loc, err := d.getLocationInfo(ctx, *item.TempOriginLocationID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get temp origin location: %w", err)
+		}
+		return loc, nil
+	}
+
+	// Fall back to item.created event location_id
+	const query = `
+		SELECT payload
+		FROM events
+		WHERE item_id = ?
+		  AND event_type = 'item.created'
+		ORDER BY event_id ASC
+		LIMIT 1
+	`
+
+	var payload []byte
+	err := d.db.QueryRowContext(ctx, query, item.ItemID).Scan(&payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query item.created event: %w", err)
+	}
+
+	var data map[string]any
+	if unmarshalErr := json.Unmarshal(payload, &data); unmarshalErr != nil {
+		return nil, fmt.Errorf("failed to parse item.created payload: %w", unmarshalErr)
+	}
+
+	locationID, ok := data["location_id"].(string)
+	if !ok || locationID == "" {
+		return nil, fmt.Errorf("item.created event missing location_id for item %s", item.ItemID)
+	}
+
+	loc, err := d.getLocationInfo(ctx, locationID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get creation location: %w", err)
+	}
+
+	return loc, nil
+}
+
+// locationCount tracks occurrence counts and most recent event_id for a location.
+type locationCount struct {
+	count      int
+	maxEventID int64
+}
+
+// scryFoundLocations returns locations where the item was previously found (item.found events).
+// Results are ordered by occurrence count descending, then most recent event_id descending.
+// System locations and locations already in seen are excluded.
+func (d *Database) scryFoundLocations(
+	ctx context.Context,
+	itemID string,
+	seen map[string]bool,
+) ([]*ScoredLocation, error) {
+	const query = `
+		SELECT event_id, payload
+		FROM events
+		WHERE item_id = ?
+		  AND event_type = 'item.found'
+		ORDER BY event_id DESC
+	`
+
+	rows, err := d.db.QueryContext(ctx, query, itemID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query item.found events: %w", err)
+	}
+	defer rows.Close()
+
+	counts := make(map[string]*locationCount)
+
+	for rows.Next() {
+		var eventID int64
+		var payload []byte
+
+		if scanErr := rows.Scan(&eventID, &payload); scanErr != nil {
+			return nil, fmt.Errorf("failed to scan item.found event: %w", scanErr)
+		}
+
+		var data map[string]any
+		if unmarshalErr := json.Unmarshal(payload, &data); unmarshalErr != nil {
+			continue // Skip malformed payloads
+		}
+
+		foundLocID, ok := data["found_location_id"].(string)
+		if !ok || foundLocID == "" {
+			continue
+		}
+
+		if lc, exists := counts[foundLocID]; exists {
+			lc.count++
+			if eventID > lc.maxEventID {
+				lc.maxEventID = eventID
+			}
+		} else {
+			counts[foundLocID] = &locationCount{count: 1, maxEventID: eventID}
+		}
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating item.found events: %w", err)
+	}
+
+	return d.buildScoredLocations(ctx, counts, seen), nil
+}
+
+// scryTempUseLocations returns locations where the item was used temporarily
+// (item.moved events with move_type=temporary_use).
+// Results are ordered by occurrence count descending, then most recent event_id descending.
+// System locations and locations already in seen are excluded.
+func (d *Database) scryTempUseLocations(
+	ctx context.Context,
+	itemID string,
+	seen map[string]bool,
+) ([]*ScoredLocation, error) {
+	const query = `
+		SELECT event_id, payload
+		FROM events
+		WHERE item_id = ?
+		  AND event_type = 'item.moved'
+		ORDER BY event_id DESC
+	`
+
+	rows, err := d.db.QueryContext(ctx, query, itemID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query item.moved events: %w", err)
+	}
+	defer rows.Close()
+
+	counts := make(map[string]*locationCount)
+
+	for rows.Next() {
+		var eventID int64
+		var payload []byte
+
+		if scanErr := rows.Scan(&eventID, &payload); scanErr != nil {
+			return nil, fmt.Errorf("failed to scan item.moved event: %w", scanErr)
+		}
+
+		var data map[string]any
+		if unmarshalErr := json.Unmarshal(payload, &data); unmarshalErr != nil {
+			continue // Skip malformed payloads
+		}
+
+		// Only include temporary_use moves
+		moveType, _ := data["move_type"].(string)
+		if moveType != "temporary_use" {
+			continue
+		}
+
+		toLocID, ok := data["to_location_id"].(string)
+		if !ok || toLocID == "" {
+			continue
+		}
+
+		if lc, exists := counts[toLocID]; exists {
+			lc.count++
+			if eventID > lc.maxEventID {
+				lc.maxEventID = eventID
+			}
+		} else {
+			counts[toLocID] = &locationCount{count: 1, maxEventID: eventID}
+		}
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating item.moved events: %w", err)
+	}
+
+	return d.buildScoredLocations(ctx, counts, seen), nil
+}
+
+// buildScoredLocations converts a counts map into a sorted []*ScoredLocation slice.
+// Locations that are system locations or already in seen are excluded.
+// Locations added to the result are also added to seen.
+func (d *Database) buildScoredLocations(
+	ctx context.Context,
+	counts map[string]*locationCount,
+	seen map[string]bool,
+) []*ScoredLocation {
+	// Build sorted list of location IDs
+	type locEntry struct {
+		locationID string
+		count      int
+		maxEventID int64
+	}
+
+	entries := make([]locEntry, 0, len(counts))
+	for locID, lc := range counts {
+		entries = append(entries, locEntry{
+			locationID: locID,
+			count:      lc.count,
+			maxEventID: lc.maxEventID,
+		})
+	}
+
+	// Sort by count desc, then maxEventID desc
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].count != entries[j].count {
+			return entries[i].count > entries[j].count
+		}
+		return entries[i].maxEventID > entries[j].maxEventID
+	})
+
+	var results []*ScoredLocation
+	for _, entry := range entries {
+		if seen[entry.locationID] {
+			continue
+		}
+
+		loc, err := d.getLocationInfo(ctx, entry.locationID)
+		if err != nil {
+			continue // Skip if location not found (deleted location, etc.)
+		}
+
+		if loc.IsSystem {
+			continue // Skip system locations
+		}
+
+		seen[entry.locationID] = true
+		results = append(results, &ScoredLocation{
+			Location:    loc,
+			Occurrences: entry.count,
+		})
+	}
+
+	return results
+}
+
+// scrySimilarItemLocations returns locations of items with similar canonical names.
+// Uses a LIKE pre-filter then Go-side Levenshtein checking.
+// Results are ordered by Levenshtein distance ascending.
+// System locations and locations already in seen are excluded.
+func (d *Database) scrySimilarItemLocations(
+	ctx context.Context,
+	canonicalName string,
+	itemID string,
+	seen map[string]bool,
+) ([]*ScoredLocation, error) {
+	candidates, err := d.querySimilarItemCandidates(ctx, canonicalName, itemID)
+	if err != nil {
+		return nil, err
+	}
+
+	return filterAndSortSimilarCandidates(candidates, canonicalName, seen), nil
+}
+
+// similarCandidate holds data for a single similar-item candidate row.
+type similarCandidate struct {
+	location    *LocationInfo
+	itemName    string // canonical name of the similar item
+	displayName string // display name of the similar item
+	distance    int
+}
+
+// querySimilarItemCandidates fetches and pre-filters candidates from the database.
+// Returns one candidate per location (lowest Levenshtein distance wins per location).
+func (d *Database) querySimilarItemCandidates(
+	ctx context.Context,
+	canonicalName string,
+	itemID string,
+) (map[string]*similarCandidate, error) {
+	// SQL pre-filter: substring match to reduce candidates
+	searchPattern := "%" + canonicalName + "%"
+
+	const query = `
+		SELECT i.item_id, i.canonical_name, i.display_name, i.location_id,
+		       l.display_name, l.full_path_display, l.is_system
+		FROM items_current i
+		INNER JOIN locations_current l ON i.location_id = l.location_id
+		WHERE i.canonical_name LIKE ?
+		  AND i.item_id != ?
+		  AND l.is_system = 0
+	`
+
+	rows, err := d.db.QueryContext(ctx, query, searchPattern, itemID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query similar items: %w", err)
+	}
+	defer rows.Close()
+
+	bestByLocation := make(map[string]*similarCandidate)
+
+	for rows.Next() {
+		var (
+			candidateItemID  string
+			candidateCanon   string
+			candidateDisplay string
+			locationID       string
+			locDisplayName   string
+			locFullPath      string
+			locIsSystemInt   int
+		)
+
+		if scanErr := rows.Scan(
+			&candidateItemID,
+			&candidateCanon,
+			&candidateDisplay,
+			&locationID,
+			&locDisplayName,
+			&locFullPath,
+			&locIsSystemInt,
+		); scanErr != nil {
+			return nil, fmt.Errorf("failed to scan similar item row: %w", scanErr)
+		}
+
+		dist := levenshtein.ComputeDistance(canonicalName, candidateCanon)
+		if dist > similarityThreshold {
+			continue
+		}
+
+		loc := &LocationInfo{
+			LocationID:      locationID,
+			DisplayName:     locDisplayName,
+			FullPathDisplay: locFullPath,
+			IsSystem:        locIsSystemInt != 0,
+		}
+
+		if existing, ok := bestByLocation[locationID]; !ok || dist < existing.distance {
+			bestByLocation[locationID] = &similarCandidate{
+				location:    loc,
+				itemName:    candidateCanon,
+				displayName: candidateDisplay,
+				distance:    dist,
+			}
+		}
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating similar items: %w", err)
+	}
+
+	return bestByLocation, nil
+}
+
+// filterAndSortSimilarCandidates converts the bestByLocation map into a sorted
+// []*ScoredLocation slice, skipping locations already in seen.
+func filterAndSortSimilarCandidates(
+	bestByLocation map[string]*similarCandidate,
+	_ string,
+	seen map[string]bool,
+) []*ScoredLocation {
+	candidates := make([]*similarCandidate, 0, len(bestByLocation))
+	for _, c := range bestByLocation {
+		candidates = append(candidates, c)
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].distance != candidates[j].distance {
+			return candidates[i].distance < candidates[j].distance
+		}
+		return candidates[i].location.FullPathDisplay < candidates[j].location.FullPathDisplay
+	})
+
+	var results []*ScoredLocation
+	for _, c := range candidates {
+		if seen[c.location.LocationID] {
+			continue
+		}
+
+		seen[c.location.LocationID] = true
+		results = append(results, &ScoredLocation{
+			Location:               c.location,
+			SimilarItemName:        c.itemName,
+			SimilarItemDisplayName: c.displayName,
+			LevenshteinDistance:    c.distance,
+		})
+	}
+
+	return results
+}

--- a/internal/database/scry_test.go
+++ b/internal/database/scry_test.go
@@ -1,0 +1,133 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestScryItem_BasicHomeLocation verifies home location is populated from creation event.
+func TestScryItem_BasicHomeLocation(t *testing.T) {
+	db := NewTestDBWithSeed(t)
+	ctx := t.Context()
+
+	// Get item created in Toolbox
+	socketItem, err := db.GetItem(ctx, TestItem10mmSocket)
+	require.NoError(t, err)
+	require.NotNil(t, socketItem)
+
+	result, err := db.ScryItem(ctx, socketItem)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Home location should be Toolbox (where item was created)
+	require.NotNil(t, result.HomeLocation)
+	assert.Equal(t, TestLocationToolbox, result.HomeLocation.LocationID)
+}
+
+// TestScryItem_NoHistoryBeyondCreation verifies minimal history shows only home location.
+func TestScryItem_NoHistoryBeyondCreation(t *testing.T) {
+	db := NewTestDBWithSeed(t)
+	ctx := t.Context()
+
+	// 10mm Socket has no found or temp-use history in seed data
+	socketItem, err := db.GetItem(ctx, TestItem10mmSocket)
+	require.NoError(t, err)
+
+	result, err := db.ScryItem(ctx, socketItem)
+	require.NoError(t, err)
+
+	// Should only have home location
+	require.NotNil(t, result.HomeLocation)
+	require.Empty(t, result.FoundLocations)
+	require.Empty(t, result.TempUseLocations)
+}
+
+// TestScryItem_SimilarItemLocationsIncluded verifies similar items appear.
+func TestScryItem_SimilarItemLocationsIncluded(t *testing.T) {
+	db := NewTestDBWithSeed(t)
+	ctx := t.Context()
+
+	item, err := db.GetItem(ctx, TestItem10mmSocket)
+	require.NoError(t, err)
+
+	result, err := db.ScryItem(ctx, item)
+	require.NoError(t, err)
+
+	// Similar item locations may or may not exist depending on seed data
+	// Just verify the structure is correct if they exist
+	for _, sl := range result.SimilarItemLocations {
+		assert.NotEmpty(t, sl.SimilarItemName)
+		assert.GreaterOrEqual(t, sl.LevenshteinDistance, 0)
+		assert.NotNil(t, sl.Location)
+	}
+}
+
+// TestScryItem_ResultStructureValid verifies all result fields are properly populated.
+func TestScryItem_ResultStructureValid(t *testing.T) {
+	db := NewTestDBWithSeed(t)
+	ctx := t.Context()
+
+	// Test with a simple item
+	item, err := db.GetItem(ctx, TestItem10mmSocket)
+	require.NoError(t, err)
+
+	result, err := db.ScryItem(ctx, item)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify structure
+	assert.Equal(t, item.ItemID, result.ItemID)
+	assert.Equal(t, item.DisplayName, result.DisplayName)
+	assert.Equal(t, item.CanonicalName, result.CanonicalName)
+
+	// Home location should always be present
+	require.NotNil(t, result.HomeLocation)
+	assert.NotEmpty(t, result.HomeLocation.LocationID)
+
+	// Category lists should exist as slices (may be empty, so check not nil)
+	// In Go, empty slices may be nil or []ScoredLocation{}, both are valid
+	// We just verify the structure is present
+	assert.IsType(t, []*ScoredLocation{}, result.FoundLocations)
+	assert.IsType(t, []*ScoredLocation{}, result.TempUseLocations)
+	assert.IsType(t, []*ScoredLocation{}, result.SimilarItemLocations)
+}
+
+// TestScryItem_HomeLocationNeverNil verifies home location is guaranteed non-nil.
+func TestScryItem_HomeLocationNeverNil(t *testing.T) {
+	db := NewTestDBWithSeed(t)
+	ctx := t.Context()
+
+	// Test multiple items
+	for _, itemID := range []string{TestItem10mmSocket, TestItemHammer, TestItemDrillBits} {
+		item, err := db.GetItem(ctx, itemID)
+		require.NoError(t, err)
+
+		result, err := db.ScryItem(ctx, item)
+		require.NoError(t, err)
+
+		// Home location must never be nil per spec
+		assert.NotNil(t, result.HomeLocation, "item %s should have home location", itemID)
+		assert.NotEmpty(t, result.HomeLocation.LocationID)
+	}
+}
+
+// TestScryItem_AllItemsHaveHomeLocation verifies all seeded items have home locations.
+func TestScryItem_AllItemsHaveHomeLocation(t *testing.T) {
+	db := NewTestDBWithSeed(t)
+	ctx := t.Context()
+
+	// Test multiple items to ensure consistency
+	for _, itemID := range []string{TestItemScrewdriverSet, TestItemSandpaper} {
+		item, err := db.GetItem(ctx, itemID)
+		require.NoError(t, err)
+
+		result, err := db.ScryItem(ctx, item)
+		require.NoError(t, err)
+
+		// Home location must always be present per spec
+		assert.NotNil(t, result.HomeLocation, "item %s must have home location", itemID)
+		assert.NotEmpty(t, result.HomeLocation.LocationID)
+	}
+}

--- a/internal/database/search.go
+++ b/internal/database/search.go
@@ -57,7 +57,7 @@ func (d *Database) SearchByName(
 	searchPattern := "%" + canonicalSearchTerm + "%"
 
 	// Get system location IDs for missing/borrowed/loaned detection
-	missingLocationID, borrowedLocationID, loanedLocationID, err := d.getSystemLocationIDs(ctx)
+	missingLocationID, borrowedLocationID, loanedLocationID, err := d.GetSystemLocationIDs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get system location IDs: %w", err)
 	}
@@ -233,9 +233,9 @@ func (d *Database) enrichResultsWithLastNonSystemLocation(ctx context.Context, r
 	}
 }
 
-// getSystemLocationIDs retrieves the UUIDs of the Missing, Borrowed, and Loaned system locations.
+// GetSystemLocationIDs retrieves the UUIDs of the Missing, Borrowed, and Loaned system locations.
 // Returns (missingID, borrowedID, loanedID, error).
-func (d *Database) getSystemLocationIDs(ctx context.Context) (string, string, string, error) {
+func (d *Database) GetSystemLocationIDs(ctx context.Context) (string, string, string, error) {
 	// Check cache first
 	if d.missingLocationID != "" && d.borrowedLocationID != "" && d.loanedLocationID != "" {
 		return d.missingLocationID, d.borrowedLocationID, d.loanedLocationID, nil

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -9,11 +9,32 @@
   cfg = config.programs.wherehouse;
   tomlFormat = pkgs.formats.toml {};
 
-  # Build the settings attrset, omitting null/empty values so wherehouse's
-  # runtime defaults (XDG dirs, etc.) are not overridden.
+  # Build the [database] section, omitting null values.
+  dbSettings = lib.filterAttrs (_: v: v != null) {
+    path = cfg.settings.database.path;
+  };
+
+  # Build the [user] section, omitting null/empty values.
+  userSettings =
+    lib.filterAttrs (_: v: v != null) {
+      default_identity = cfg.settings.user.defaultIdentity;
+    }
+    // lib.optionalAttrs (cfg.settings.user.osUsernameMap != {}) {
+      os_username_map = cfg.settings.user.osUsernameMap;
+    };
+
+  # Build the [output] section, omitting null values.
+  outputSettings = lib.filterAttrs (_: v: v != null) {
+    default_format = cfg.settings.output.defaultFormat;
+    quiet = cfg.settings.output.quiet;
+  };
+
+  # Assemble only non-empty sections so wherehouse runtime defaults
+  # (XDG dirs, OS username, etc.) are not overridden when unset.
   settingsToml =
-    {}
-    // lib.optionalAttrs (cfg.settings.config-dir != null) {config-dir = cfg.settings.config-dir;};
+    lib.optionalAttrs (dbSettings != {}) {database = dbSettings;}
+    // lib.optionalAttrs (userSettings != {}) {user = userSettings;}
+    // lib.optionalAttrs (outputSettings != {}) {output = outputSettings;};
 in {
   options.programs.wherehouse = {
     enable = lib.mkEnableOption "wherehouse, a personal inventory tracker";
@@ -21,14 +42,67 @@ in {
     package = lib.mkPackageOption pkgs "wherehouse" {};
 
     settings = {
-      config-dir = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = null;
-        description = ''
-          Path to the wherehouse configuration directory.
-          When null, wherehouse uses the platform's default config directory
-          (e.g. ~/.config/wherehouse on Linux).
-        '';
+      database = {
+        path = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = ''
+            Path to the SQLite database file.
+            Supports ~ and environment variables.
+            When null, wherehouse uses the platform default:
+            $XDG_DATA_HOME/wherehouse/wherehouse.db on Linux
+            (typically ~/.local/share/wherehouse/wherehouse.db).
+          '';
+          example = "~/.local/share/wherehouse/wherehouse.db";
+        };
+      };
+
+      user = {
+        defaultIdentity = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = ''
+            Default display name used for event attribution.
+            When null or empty, wherehouse uses the current OS username.
+          '';
+          example = "alice";
+        };
+
+        osUsernameMap = lib.mkOption {
+          type = lib.types.attrsOf lib.types.str;
+          default = {};
+          description = ''
+            Map OS usernames to display names for attribution.
+            Keys are OS usernames, values are display names.
+          '';
+          example = {
+            jdoe = "John Doe";
+            asmith = "Alice Smith";
+          };
+        };
+      };
+
+      output = {
+        defaultFormat = lib.mkOption {
+          type = lib.types.nullOr (lib.types.enum ["human" "json"]);
+          default = null;
+          description = ''
+            Default output format for commands.
+            "human" produces readable output (default); "json" produces
+            machine-readable JSON.
+          '';
+          example = "human";
+        };
+
+        quiet = lib.mkOption {
+          type = lib.types.nullOr lib.types.bool;
+          default = null;
+          description = ''
+            Enable quiet mode by default, suppressing non-essential output.
+            When null, defaults to false.
+          '';
+          example = false;
+        };
       };
     };
   };


### PR DESCRIPTION
This pull request introduces the new `scry` command to suggest likely locations for missing items, significantly expands Nix packaging and installation support (including a new flake and Home Manager module), and updates documentation and configuration defaults for improved clarity and consistency.

**Major features and changes:**

### New command: `scry` for locating missing items
- Adds the `scry` command (`wherehouse scry <item>`) to suggest where to look for a missing item based on event history, with both human-readable and JSON output modes, and verbose flag for extra detail. The command is documented, integrated into the CLI, and explained in both user and design documentation. (`cmd/scry/scry.go`, `cmd/scry/doc.go`, `cmd/root.go`, `README.md`, `docs/DESIGN.md`) [[1]](diffhunk://#diff-7edecc43fa4116e3de9d4597dd78ec637635fe7ede142f0094befcc39e55bf19R1-R294) [[2]](diffhunk://#diff-ea5eeb09b040bf9408674eb0584c4c83717a51f347691500f87a7ee3bf5058f1R1-R2) [[3]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR17) [[4]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR64) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L391-R524) [[6]](diffhunk://#diff-27a16279e23cd453bac62f1ee7c261af722d17fb592ae422755a4ba7b9dbee90R43) [[7]](diffhunk://#diff-27a16279e23cd453bac62f1ee7c261af722d17fb592ae422755a4ba7b9dbee90R362-R402)

### Nix packaging and flake support
- Adds a `flake.nix` for Nix-based builds, overlays, and Home Manager integration, enabling easy installation and configuration via Nix, Home Manager, and as an overlay. (`flake.nix`)
- Updates the documentation to include detailed Nix installation instructions, Home Manager usage, and NixOS overlay integration. (`README.md`)

### Configuration and documentation improvements
- Updates default configuration file paths and environment variable names for clarity and consistency (e.g., `wherehouse.toml`, `WHEREHOUSE_DATABASE_PATH`), and revises the example config and documentation accordingly. (`README.md`)
- Documents the new Home Manager module and its configuration options in detail, including a table of all available settings. (`README.md`)

### Release and packaging automation
- Adds a `.goreleaser.yml` configuration for automated builds, archives, checksums, and Linux packaging (apk, deb, rpm), including shell completions and manpages. (`.goreleaser.yml`)

---

**References:**  
[[1]](diffhunk://#diff-7edecc43fa4116e3de9d4597dd78ec637635fe7ede142f0094befcc39e55bf19R1-R294) [[2]](diffhunk://#diff-ea5eeb09b040bf9408674eb0584c4c83717a51f347691500f87a7ee3bf5058f1R1-R2) [[3]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR17) [[4]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR64) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R117-R157) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L391-R524) [[7]](diffhunk://#diff-27a16279e23cd453bac62f1ee7c261af722d17fb592ae422755a4ba7b9dbee90R43) [[8]](diffhunk://#diff-27a16279e23cd453bac62f1ee7c261af722d17fb592ae422755a4ba7b9dbee90R362-R402) [[9]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R1-R103) [[10]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R1-R116)