### PR TITLE
Add initialize and list commands with README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 ## Quick Example
 
 ```bash
-# Initialize your inventory
-wherehouse init
+# Initialize your inventory database
+wherehouse initialize database
 
 # Create location hierarchy
 wherehouse add location Garage
@@ -179,16 +179,26 @@ mise run dev
 
 ## Quick Start
 
-### 1. Initialize Config
+### 1. Initialize Database
+
+```bash
+wherehouse initialize database
+# → Database initialized: ~/.local/share/wherehouse/wherehouse.db
+
+# If the database already exists, use --force to reinitialize (backs up first)
+wherehouse initialize database --force
+# → Backup created: ~/.local/share/wherehouse/wherehouse.db.backup.20260226
+# → Database initialized: ~/.local/share/wherehouse/wherehouse.db
+```
+
+### 2. Initialize Config
 
 ```bash
 wherehouse config init
-# → Created database at ~/.local/share/wherehouse/inventory.db
-# → Initialized event log and projections
-# → Created system locations (Missing, Borrowed)
+# → Created config at ~/.config/wherehouse/wherehouse.toml
 ```
 
-### 2. Create Location Hierarchy
+### 3. Create Location Hierarchy
 
 ```bash
 # Create top-level locations
@@ -201,7 +211,7 @@ wherehouse add location Toolbox --in Garage
 wherehouse add location "Socket Set" --in Toolbox
 ```
 
-### 3. Add Items
+### 4. Add Items
 
 ```bash
 # Add item to specific location
@@ -214,7 +224,7 @@ wherehouse add item "step ladder" "work bench" "tool cart" --in Garage
 wherehouse add item "3/8\" drive ratchet" --in Toolbox
 ```
 
-### 4. Find Items
+### 5. Find Items
 
 ```bash
 # Search by name (substring matching)
@@ -247,7 +257,7 @@ wherehouse find "wrench"
 #   Currently: Missing
 ```
 
-### 5. View Item History
+### 6. View Item History
 
 ```bash
 # Show complete event timeline (newest first)
@@ -280,7 +290,7 @@ wherehouse history "socket" --json
 wherehouse history --id "01HXXX-XXXX-..."
 ```
 
-### 6. Move Items
+### 7. Move Items
 
 ```bash
 # Permanent move (rehome)
@@ -296,7 +306,7 @@ wherehouse move "paint roller" "Bedroom" --project "bedroom-repaint"
 wherehouse move "roller" Basement --keep-project
 ```
 
-### 7. Track Missing Items
+### 8. Track Missing Items
 
 ```bash
 # Mark as missing
@@ -346,7 +356,7 @@ Project Management:
   project delete       Remove project (if no items) (coming soon)
 
 Database Operations:
-  init                 Initialize new database (coming soon)
+  initialize database ✅  Initialize new database (--force to overwrite with backup)
   doctor               Validate database consistency (partial)
   export               Export events and projections (coming soon)
   import               Import from export file (coming soon)
@@ -878,8 +888,10 @@ mise run ci
   - [x] `history` - Show complete event timeline for items
   - [x] `move` - Move items between locations (selectors, project tracking, temporary moves)
   - [x] `config` subcommands (init, get, set, check, edit, path) - viper-backed configuration
+  - [x] `initialize database` - create SQLite database with `--force` backup/overwrite
   - [x] Basic output formatting (human-readable, JSON, quiet modes)
   - [x] Flag overrides: `--db`, `--as` override config file values at runtime
+  - [x] Clear error when database file is missing (guides user to `initialize database`)
 
 ### 🚧 In Progress (v0.2.0 - Alpha)
 
@@ -946,9 +958,8 @@ ls -ld ~/.local/share/wherehouse/
 # Create directory if missing
 mkdir -p ~/.local/share/wherehouse
 
-# Remove corrupted database (backup first!)
-mv ~/.local/share/wherehouse/inventory.db{,.bak}
-wherehouse init
+# Reinitialize database (backs up existing file automatically)
+wherehouse initialize database --force
 ```
 
 ### `SQLITE_BUSY` or lock errors
@@ -1000,8 +1011,7 @@ ls -lh ~/.local/share/wherehouse/inventory.db
 
 # Export and reimport for defragmentation
 wherehouse export > backup.json
-mv ~/.local/share/wherehouse/inventory.db{,.old}
-wherehouse init
+wherehouse initialize database --force
 wherehouse import < backup.json
 ```
 

--- a/cmd/initialize/database.go
+++ b/cmd/initialize/database.go
@@ -1,0 +1,189 @@
+package initialize
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/asphaltbuffet/wherehouse/internal/config"
+	"github.com/asphaltbuffet/wherehouse/internal/database"
+)
+
+var databaseCmd *cobra.Command
+
+// GetDatabaseCmd returns the `initialize database` subcommand.
+func GetDatabaseCmd() *cobra.Command {
+	if databaseCmd != nil {
+		return databaseCmd
+	}
+
+	databaseCmd = &cobra.Command{
+		Use:   "database",
+		Short: "Create the wherehouse database",
+		Long: `Create the SQLite database and apply all migrations.
+
+Fails if the database already exists. Use --force to reinitialize.
+The --force flag renames the existing database to <path>.backup.<YYYYMMDD>
+before creating a fresh one.
+
+The database path is controlled by the root --db flag or the database.path
+config value. Default: $XDG_DATA_HOME/wherehouse/wherehouse.db`,
+		RunE: runInitializeDatabase,
+	}
+
+	databaseCmd.Flags().Bool("force", false, "reinitialize: back up existing DB then create fresh")
+
+	return databaseCmd
+}
+
+// initResult is the structured output for JSON mode.
+type initResult struct {
+	Status     string `json:"status"`
+	Path       string `json:"path"`
+	BackupPath string `json:"backup_path,omitempty"`
+}
+
+func runInitializeDatabase(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+
+	cfg, ok := ctx.Value(config.ConfigKey).(*config.Config)
+	if !ok || cfg == nil {
+		return errors.New("configuration not found in context")
+	}
+
+	dbPath, err := cfg.GetDatabasePath()
+	if err != nil {
+		return fmt.Errorf("failed to resolve database path: %w", err)
+	}
+
+	force, _ := cmd.Flags().GetBool("force")
+
+	backupPath, err := handleExistingDatabase(cmd, dbPath, force)
+	if err != nil {
+		return err
+	}
+
+	// Ensure parent directory exists (XDG data dir may not exist on fresh install).
+	if mkdirErr := os.MkdirAll(filepath.Dir(dbPath), 0o700); mkdirErr != nil {
+		return fmt.Errorf("could not create database directory: %w", mkdirErr)
+	}
+
+	// Open (creates file) with migrations.
+	dbConfig := database.Config{
+		Path:        dbPath,
+		BusyTimeout: database.DefaultBusyTimeout,
+		AutoMigrate: true,
+	}
+
+	db, openErr := database.Open(dbConfig)
+	if openErr != nil {
+		return fmt.Errorf("database initialization failed: %w", openErr)
+	}
+
+	_ = db.Close()
+
+	// Output.
+	return printInitResult(cmd, cfg, dbPath, backupPath)
+}
+
+// handleExistingDatabase checks whether a database file already exists at dbPath
+// and handles it according to the force flag:
+//   - not exists: returns ("", nil) — proceed normally
+//   - exists, !force: returns an error
+//   - exists, force: attempts backup rename; on failure warns and removes original
+//
+// Returns (backupPath, nil) on success, or ("", error) on fatal failure.
+func handleExistingDatabase(cmd *cobra.Command, dbPath string, force bool) (string, error) {
+	_, statErr := os.Stat(dbPath)
+	if errors.Is(statErr, os.ErrNotExist) {
+		return "", nil
+	}
+
+	if statErr != nil {
+		return "", fmt.Errorf("could not check database path: %w", statErr)
+	}
+
+	// File exists.
+	if !force {
+		return "", fmt.Errorf("database already exists at %q: use --force to reinitialize", dbPath)
+	}
+
+	// --force: attempt timestamped backup.
+	backupPath, err := backupDatabase(dbPath)
+	if err != nil {
+		// Backup failed: warn and continue (best-effort).
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not back up existing database: %v\n", err)
+
+		// Remove the existing file so Open can create a fresh one.
+		if removeErr := os.Remove(dbPath); removeErr != nil {
+			return "", fmt.Errorf("could not remove existing database for reinitialization: %w", removeErr)
+		}
+
+		return "", nil
+	}
+
+	return backupPath, nil
+}
+
+// backupDatabase renames dbPath to dbPath.backup.<YYYYMMDD>.
+// If that target already exists, it appends a counter suffix (.1, .2, ...).
+// Returns the backup path on success, or an error.
+func backupDatabase(dbPath string) (string, error) {
+	dateSuffix := time.Now().Format("20060102")
+	candidate := dbPath + ".backup." + dateSuffix
+
+	// Resolve collision with counter suffix.
+	if _, err := os.Stat(candidate); err == nil {
+		found := false
+
+		for i := 1; i <= 99; i++ {
+			candidate = fmt.Sprintf("%s.backup.%s.%d", dbPath, dateSuffix, i)
+			if _, statErr := os.Stat(candidate); errors.Is(statErr, os.ErrNotExist) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return "", fmt.Errorf("too many backups for %s on date %s", dbPath, dateSuffix)
+		}
+	}
+
+	if err := os.Rename(dbPath, candidate); err != nil {
+		return "", err
+	}
+
+	return candidate, nil
+}
+
+func printInitResult(cmd *cobra.Command, cfg *config.Config, dbPath, backupPath string) error {
+	if cfg.IsJSON() {
+		result := initResult{
+			Status:     "initialized",
+			Path:       dbPath,
+			BackupPath: backupPath,
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+
+		return enc.Encode(result)
+	}
+
+	if cfg.IsQuiet() {
+		return nil
+	}
+
+	// Human-readable.
+	if backupPath != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Backed up existing database to %s\n", backupPath)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Database initialized at %s\n", dbPath)
+
+	return nil
+}

--- a/cmd/initialize/database_test.go
+++ b/cmd/initialize/database_test.go
@@ -1,0 +1,290 @@
+package initialize
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/asphaltbuffet/wherehouse/internal/config"
+)
+
+// resetForTesting resets package-level command singletons between tests.
+func resetForTesting() {
+	databaseCmd = nil
+	initializeCmd = nil
+}
+
+// makeTestConfig returns a *config.Config pointing the database path to the given path.
+func makeTestConfig(dbPath string) *config.Config {
+	cfg := config.GetDefaults()
+	cfg.Database.Path = dbPath
+	return cfg
+}
+
+// runDatabaseCmd executes `initialize database` with the given args and config.
+// Returns stdout, stderr, and any error.
+func runDatabaseCmd(t *testing.T, cfg *config.Config, args ...string) (string, string, error) {
+	t.Helper()
+
+	resetForTesting()
+
+	cmd := GetDatabaseCmd()
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	cmd.SetOut(outBuf)
+	cmd.SetErr(errBuf)
+
+	ctx := context.WithValue(context.Background(), config.ConfigKey, cfg)
+	cmd.SetContext(ctx)
+
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+
+	return outBuf.String(), errBuf.String(), err
+}
+
+func TestRunInitializeDatabase_FreshInstall(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "sub", "wherehouse.db")
+	cfg := makeTestConfig(dbPath)
+
+	stdout, _, err := runDatabaseCmd(t, cfg)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Database initialized at")
+	assert.Contains(t, stdout, dbPath)
+
+	_, statErr := os.Stat(dbPath)
+	assert.NoError(t, statErr, "database file should exist")
+}
+
+func TestRunInitializeDatabase_DirExists_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "wherehouse.db")
+	cfg := makeTestConfig(dbPath)
+
+	stdout, _, err := runDatabaseCmd(t, cfg)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout, dbPath)
+
+	_, statErr := os.Stat(dbPath)
+	assert.NoError(t, statErr, "database file should exist")
+}
+
+func TestRunInitializeDatabase_AlreadyExists_NoForce(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "wherehouse.db")
+
+	// Create an existing file.
+	require.NoError(t, os.WriteFile(dbPath, []byte("existing"), 0o600))
+
+	cfg := makeTestConfig(dbPath)
+
+	_, _, err := runDatabaseCmd(t, cfg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database already exists")
+	assert.Contains(t, err.Error(), "--force")
+
+	// Original file must be untouched.
+	data, readErr := os.ReadFile(dbPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "existing", string(data))
+}
+
+func TestRunInitializeDatabase_AlreadyExists_Force_BackupCreated(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "wherehouse.db")
+
+	require.NoError(t, os.WriteFile(dbPath, []byte("old-db"), 0o600))
+
+	cfg := makeTestConfig(dbPath)
+
+	stdout, stderr, err := runDatabaseCmd(t, cfg, "--force")
+
+	require.NoError(t, err)
+	assert.Empty(t, stderr, "no warning expected on successful backup")
+	assert.Contains(t, stdout, "Backed up existing database to")
+	assert.Contains(t, stdout, "Database initialized at")
+
+	dateSuffix := time.Now().Format("20060102")
+	backupPath := dbPath + ".backup." + dateSuffix
+
+	_, statErr := os.Stat(backupPath)
+	require.NoError(t, statErr, "backup file should exist at %s", backupPath)
+
+	data, readErr := os.ReadFile(backupPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "old-db", string(data), "backup should contain original content")
+
+	_, statErr = os.Stat(dbPath)
+	require.NoError(t, statErr, "new database should exist")
+}
+
+func TestRunInitializeDatabase_AlreadyExists_Force_BackupCollision(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "wherehouse.db")
+	dateSuffix := time.Now().Format("20060102")
+
+	// Create original and primary backup (simulate collision).
+	require.NoError(t, os.WriteFile(dbPath, []byte("old-db"), 0o600))
+
+	primaryBackup := dbPath + ".backup." + dateSuffix
+	require.NoError(t, os.WriteFile(primaryBackup, []byte("earlier-backup"), 0o600))
+
+	cfg := makeTestConfig(dbPath)
+
+	stdout, _, err := runDatabaseCmd(t, cfg, "--force")
+
+	require.NoError(t, err)
+
+	// Counter-suffixed backup should exist.
+	collisionBackup := fmt.Sprintf("%s.backup.%s.1", dbPath, dateSuffix)
+	_, statErr := os.Stat(collisionBackup)
+	require.NoError(t, statErr, "collision backup file should exist at %s", collisionBackup)
+
+	assert.Contains(t, stdout, collisionBackup)
+}
+
+func TestRunInitializeDatabase_JSONOutput(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "wherehouse.db")
+	cfg := makeTestConfig(dbPath)
+	cfg.Output.DefaultFormat = "json"
+
+	stdout, _, err := runDatabaseCmd(t, cfg)
+
+	require.NoError(t, err)
+
+	var result initResult
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	assert.Equal(t, "initialized", result.Status)
+	assert.Equal(t, dbPath, result.Path)
+	assert.Empty(t, result.BackupPath)
+}
+
+func TestRunInitializeDatabase_JSONOutput_WithBackup(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "wherehouse.db")
+	require.NoError(t, os.WriteFile(dbPath, []byte("old"), 0o600))
+
+	cfg := makeTestConfig(dbPath)
+	cfg.Output.DefaultFormat = "json"
+
+	stdout, _, err := runDatabaseCmd(t, cfg, "--force")
+
+	require.NoError(t, err)
+
+	var result initResult
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	assert.Equal(t, "initialized", result.Status)
+	assert.Equal(t, dbPath, result.Path)
+	assert.NotEmpty(t, result.BackupPath)
+
+	dateSuffix := time.Now().Format("20060102")
+	assert.Contains(t, result.BackupPath, ".backup."+dateSuffix)
+}
+
+func TestRunInitializeDatabase_NoConfig(t *testing.T) {
+	resetForTesting()
+
+	cmd := GetDatabaseCmd()
+	cmd.SetContext(context.Background()) // no config in context
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "configuration not found in context")
+}
+
+func TestRunInitializeDatabase_QuietMode_SuppressesOutput(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "wherehouse.db")
+	cfg := makeTestConfig(dbPath)
+	cfg.Output.Quiet = 1
+
+	stdout, _, err := runDatabaseCmd(t, cfg)
+
+	require.NoError(t, err)
+	assert.Empty(t, stdout, "quiet mode should suppress human-readable output")
+
+	_, statErr := os.Stat(dbPath)
+	assert.NoError(t, statErr, "database file should still be created in quiet mode")
+}
+
+func TestBackupDatabase_NoCollision(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	require.NoError(t, os.WriteFile(dbPath, []byte("data"), 0o600))
+
+	dateSuffix := time.Now().Format("20060102")
+	expected := dbPath + ".backup." + dateSuffix
+
+	result, err := backupDatabase(dbPath)
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+
+	_, statErr := os.Stat(result)
+	assert.NoError(t, statErr)
+}
+
+func TestBackupDatabase_WithCollision(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	require.NoError(t, os.WriteFile(dbPath, []byte("data"), 0o600))
+
+	dateSuffix := time.Now().Format("20060102")
+	primaryBackup := dbPath + ".backup." + dateSuffix
+	require.NoError(t, os.WriteFile(primaryBackup, []byte("prev"), 0o600))
+
+	expected := fmt.Sprintf("%s.backup.%s.1", dbPath, dateSuffix)
+
+	result, err := backupDatabase(dbPath)
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+
+	_, statErr := os.Stat(result)
+	assert.NoError(t, statErr)
+}
+
+func TestBackupDatabase_SourceMissing(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "nonexistent.db")
+
+	_, err := backupDatabase(dbPath)
+
+	require.Error(t, err)
+}
+
+func TestBackupDatabase_SlotExhaustion(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	require.NoError(t, os.WriteFile(dbPath, []byte("data"), 0o600))
+
+	dateSuffix := time.Now().Format("20060102")
+
+	// Create the primary backup and all 99 counter-suffixed backups.
+	primaryBackup := dbPath + ".backup." + dateSuffix
+	require.NoError(t, os.WriteFile(primaryBackup, []byte("prev"), 0o600))
+
+	for i := 1; i <= 99; i++ {
+		slot := fmt.Sprintf("%s.backup.%s.%d", dbPath, dateSuffix, i)
+		require.NoError(t, os.WriteFile(slot, []byte("prev"), 0o600))
+	}
+
+	_, err := backupDatabase(dbPath)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too many backups")
+}

--- a/cmd/initialize/doc.go
+++ b/cmd/initialize/doc.go
@@ -1,0 +1,3 @@
+// Package initialize provides the `wherehouse initialize` command group for
+// first-time setup of wherehouse resources.
+package initialize

--- a/cmd/initialize/initialize.go
+++ b/cmd/initialize/initialize.go
@@ -1,0 +1,29 @@
+package initialize
+
+import "github.com/spf13/cobra"
+
+var initializeCmd *cobra.Command
+
+// GetInitializeCmd returns the initialize command group. The parent command shows help only;
+// action is delegated to subcommands (e.g., `initialize database`).
+func GetInitializeCmd() *cobra.Command {
+	if initializeCmd != nil {
+		return initializeCmd
+	}
+
+	initializeCmd = &cobra.Command{
+		Use:     "initialize",
+		Aliases: []string{"init"},
+		Short:   "Initialize wherehouse resources",
+		Long: `Initialize wherehouse resources for first-time setup.
+
+Examples:
+  wherehouse initialize database           Create the database
+  wherehouse initialize database --force   Reinitialize (backs up existing database)`,
+		// No RunE: displays help when called without a subcommand.
+	}
+
+	initializeCmd.AddCommand(GetDatabaseCmd())
+
+	return initializeCmd
+}

--- a/cmd/list/doc.go
+++ b/cmd/list/doc.go
@@ -1,0 +1,21 @@
+// Package list implements the wherehouse list command for displaying
+// locations and their items in a tree view.
+//
+// The list command shows items in one or more locations using a tree-style
+// display. Without arguments, it shows all root-level locations. With
+// arguments, it shows only the specified locations.
+//
+// In non-recursive mode (default), each location shows its direct items and
+// hints for direct child locations (with item and location counts). In
+// recursive mode (--recurse / -r), the full subtree is displayed.
+//
+// Location arguments that cannot be resolved are rendered inline as
+// "[arg] [not found]" and do not cause a non-zero exit code.
+//
+// Examples:
+//
+//	wherehouse list
+//	wherehouse list Garage
+//	wherehouse list -r Garage Office
+//	wherehouse list --json Garage
+package list

--- a/cmd/list/helpers.go
+++ b/cmd/list/helpers.go
@@ -1,0 +1,23 @@
+package list
+
+import (
+	"context"
+
+	"github.com/asphaltbuffet/wherehouse/internal/cli"
+	"github.com/asphaltbuffet/wherehouse/internal/database"
+)
+
+// openDatabase opens the database connection using config settings.
+func openDatabase(ctx context.Context) (*database.Database, error) {
+	if testOpenDatabase != nil {
+		return testOpenDatabase(ctx)
+	}
+	return cli.OpenDatabase(ctx)
+}
+
+// resolveLocation resolves a location name or UUID to the location UUID string.
+// Accepts either a full UUID (verified against database) or a display/canonical name.
+// Returns the location UUID string or error if not found.
+func resolveLocation(ctx context.Context, db *database.Database, input string) (string, error) {
+	return cli.ResolveLocation(ctx, db, input)
+}

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -1,0 +1,240 @@
+package list
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/goccy/go-json"
+	"github.com/spf13/cobra"
+
+	"github.com/asphaltbuffet/wherehouse/internal/cli"
+	"github.com/asphaltbuffet/wherehouse/internal/config"
+	"github.com/asphaltbuffet/wherehouse/internal/database"
+)
+
+var (
+	listCmd *cobra.Command
+	//nolint: gochecknoglobals // Test hooks for dependency injection
+	testOpenDatabase  func(context.Context) (*database.Database, error)
+	testMustGetConfig func(context.Context) *config.Config
+)
+
+// GetListCmd returns the list command, initializing it if necessary.
+func GetListCmd() *cobra.Command {
+	if listCmd != nil {
+		return listCmd
+	}
+
+	listCmd = &cobra.Command{
+		Use:   "list [<location>...]",
+		Short: "List items in locations",
+		Long: `List items in one or more locations.
+
+Without arguments, shows all top-level locations and their direct items.
+Direct child locations are shown as hints with item and location counts.
+
+With location arguments, shows items in those specific locations.
+If a location argument cannot be resolved, it is shown inline as
+"[arg] [not found]" and does not cause a non-zero exit.
+
+Use --recurse (-r) to include sub-locations and all their contents.
+
+Examples:
+  wherehouse list
+  wherehouse list Garage
+  wherehouse list "Garage" "Office"
+  wherehouse list --recurse
+  wherehouse list -r Garage`,
+		Args: cobra.ArbitraryArgs,
+		RunE: runList,
+	}
+
+	listCmd.Flags().BoolP("recurse", "r", false, "recursively list sub-locations and their items")
+
+	return listCmd
+}
+
+// runList is the main entry point for the list command.
+func runList(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	recurse, _ := cmd.Flags().GetBool("recurse")
+
+	db, err := openDatabase(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to open database: %w", err)
+	}
+	defer db.Close()
+
+	var cfg *config.Config
+	if testMustGetConfig != nil {
+		cfg = testMustGetConfig(ctx)
+	} else {
+		cfg = cli.MustGetConfig(ctx)
+	}
+
+	if cfg == nil {
+		return errors.New("config not found in context")
+	}
+
+	nodes, err := buildNodes(ctx, db, args, recurse)
+	if err != nil {
+		return err
+	}
+
+	if cfg.IsJSON() {
+		output := toJSON(nodes)
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		if encErr := enc.Encode(output); encErr != nil {
+			return fmt.Errorf("failed to encode JSON output: %w", encErr)
+		}
+		return nil
+	}
+
+	renderTree(cmd.OutOrStdout(), nodes)
+	return nil
+}
+
+// buildNodes constructs the LocationNode slice for the given arguments.
+// If args is empty, root locations are used. Unresolvable args become
+// NotFound nodes (no error returned).
+func buildNodes(ctx context.Context, db *database.Database, args []string, recurse bool) ([]*LocationNode, error) {
+	if len(args) == 0 {
+		return buildRootNodes(ctx, db, recurse)
+	}
+
+	nodes := make([]*LocationNode, 0, len(args))
+	for _, arg := range args {
+		locationID, resolveErr := resolveLocation(ctx, db, arg)
+		if resolveErr != nil {
+			// Render inline as not-found; do not propagate error.
+			nodes = append(nodes, &LocationNode{NotFound: true, InputArg: arg})
+			continue
+		}
+
+		loc, locErr := db.GetLocation(ctx, locationID)
+		if locErr != nil {
+			// Should be rare (ID resolved but not fetchable); treat as not-found.
+			nodes = append(nodes, &LocationNode{NotFound: true, InputArg: arg})
+			continue
+		}
+
+		node, buildErr := buildNode(ctx, db, loc, recurse)
+		if buildErr != nil {
+			return nil, fmt.Errorf("failed to build node for %q: %w", arg, buildErr)
+		}
+		nodes = append(nodes, node)
+	}
+	return nodes, nil
+}
+
+// buildRootNodes fetches all root locations and builds a node for each.
+func buildRootNodes(ctx context.Context, db *database.Database, recurse bool) ([]*LocationNode, error) {
+	roots, err := db.GetRootLocations(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get root locations: %w", err)
+	}
+
+	nodes := make([]*LocationNode, 0, len(roots))
+	for _, loc := range roots {
+		node, buildErr := buildNode(ctx, db, loc, recurse)
+		if buildErr != nil {
+			return nil, fmt.Errorf("failed to build node for %q: %w", loc.DisplayName, buildErr)
+		}
+		nodes = append(nodes, node)
+	}
+	return nodes, nil
+}
+
+// buildNode dispatches to the flat or recursive builder based on the recurse flag.
+func buildNode(
+	ctx context.Context,
+	db *database.Database,
+	loc *database.Location,
+	recurse bool,
+) (*LocationNode, error) {
+	if recurse {
+		return buildLocationNodeRecursive(ctx, db, loc)
+	}
+	return buildLocationNodeFlat(ctx, db, loc)
+}
+
+// buildLocationNodeFlat builds a LocationNode for non-recursive display.
+// Items are populated; children are hint-only nodes (Items/Children are nil,
+// ChildItemCount and ChildLocationCount are set from lightweight DB queries).
+func buildLocationNodeFlat(ctx context.Context, db *database.Database, loc *database.Location) (*LocationNode, error) {
+	node := &LocationNode{Location: loc}
+
+	// Fetch direct items.
+	items, err := db.GetItemsByLocation(ctx, loc.LocationID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get items for %q: %w", loc.DisplayName, err)
+	}
+	node.Items = items
+
+	// Fetch direct children and build hint nodes.
+	children, err := db.GetLocationChildren(ctx, loc.LocationID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get children for %q: %w", loc.DisplayName, err)
+	}
+
+	hints := make([]*LocationNode, 0, len(children))
+	for _, child := range children {
+		childItems, childItemsErr := db.GetItemsByLocation(ctx, child.LocationID)
+		if childItemsErr != nil {
+			return nil, fmt.Errorf("failed to get items for child %q: %w", child.DisplayName, childItemsErr)
+		}
+
+		grandchildren, grandchildErr := db.GetLocationChildren(ctx, child.LocationID)
+		if grandchildErr != nil {
+			return nil, fmt.Errorf("failed to get children of child %q: %w", child.DisplayName, grandchildErr)
+		}
+
+		hints = append(hints, &LocationNode{
+			Location:           child,
+			ChildItemCount:     len(childItems),
+			ChildLocationCount: len(grandchildren),
+		})
+	}
+	node.Children = hints
+
+	return node, nil
+}
+
+// buildLocationNodeRecursive builds a fully-populated LocationNode tree.
+// Both Items and Children are populated at every level; ChildItemCount and
+// ChildLocationCount are unused in recursive mode.
+func buildLocationNodeRecursive(
+	ctx context.Context,
+	db *database.Database,
+	loc *database.Location,
+) (*LocationNode, error) {
+	node := &LocationNode{Location: loc}
+
+	// Fetch direct items.
+	items, err := db.GetItemsByLocation(ctx, loc.LocationID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get items for %q: %w", loc.DisplayName, err)
+	}
+	node.Items = items
+
+	// Fetch and recurse into children.
+	children, err := db.GetLocationChildren(ctx, loc.LocationID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get children for %q: %w", loc.DisplayName, err)
+	}
+
+	childNodes := make([]*LocationNode, 0, len(children))
+	for _, child := range children {
+		childNode, childErr := buildLocationNodeRecursive(ctx, db, child)
+		if childErr != nil {
+			return nil, childErr
+		}
+		childNodes = append(childNodes, childNode)
+	}
+	node.Children = childNodes
+
+	return node, nil
+}

--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -1,0 +1,903 @@
+package list
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/asphaltbuffet/wherehouse/internal/config"
+	"github.com/asphaltbuffet/wherehouse/internal/database"
+)
+
+// testFixture holds a test database with pre-populated data.
+type testFixture struct {
+	db          *database.Database
+	ctx         context.Context
+	garageID    string
+	shelfAID    string
+	workbenchID string
+	drawer1ID   string
+	officeID    string
+	missingID   string
+	item1ID     string // drill (garage)
+	item2ID     string // hammer (garage)
+	item3ID     string // sandpaper (shelfA)
+	item4ID     string // chisel (workbench)
+	item5ID     string // screwdriver (missing)
+}
+
+// setupListTest creates an in-memory DB with a tree of locations and items.
+//
+// Tree:
+//
+//	Garage (2 items: drill, hammer; 2 children: ShelfA, Workbench)
+//	  ShelfA (1 item: sandpaper; 0 children)
+//	  Workbench (1 item: chisel; 1 child: Drawer1)
+//	    Drawer1 (0 items; 0 children)
+//	Office (0 items; 0 children)
+//	Missing [system] (1 item: screwdriver; 0 children)
+func setupListTest(t *testing.T) testFixture {
+	t.Helper()
+
+	ctx := context.Background()
+	db, err := database.Open(database.Config{
+		Path:        ":memory:",
+		BusyTimeout: database.DefaultBusyTimeout,
+		AutoMigrate: true,
+	})
+	require.NoError(t, err)
+
+	prefix := uuid.New().String()[:8]
+	ts := "2025-01-01T00:00:00Z"
+
+	f := testFixture{
+		db:          db,
+		ctx:         ctx,
+		garageID:    uuid.New().String(),
+		shelfAID:    uuid.New().String(),
+		workbenchID: uuid.New().String(),
+		drawer1ID:   uuid.New().String(),
+		officeID:    uuid.New().String(),
+		missingID:   uuid.New().String(),
+		item1ID:     uuid.New().String(),
+		item2ID:     uuid.New().String(),
+		item3ID:     uuid.New().String(),
+		item4ID:     uuid.New().String(),
+		item5ID:     uuid.New().String(),
+	}
+
+	// Root locations
+	require.NoError(t, db.CreateLocation(ctx, f.garageID, fmt.Sprintf("Garage-%s", prefix), nil, false, 0, ts))
+	require.NoError(t, db.CreateLocation(ctx, f.officeID, fmt.Sprintf("Office-%s", prefix), nil, false, 0, ts))
+	require.NoError(t, db.CreateLocation(ctx, f.missingID, fmt.Sprintf("Missing-%s", prefix), nil, true, 0, ts))
+
+	// Child locations under Garage
+	require.NoError(t, db.CreateLocation(ctx, f.shelfAID, fmt.Sprintf("ShelfA-%s", prefix), &f.garageID, false, 0, ts))
+	require.NoError(
+		t,
+		db.CreateLocation(ctx, f.workbenchID, fmt.Sprintf("Workbench-%s", prefix), &f.garageID, false, 0, ts),
+	)
+
+	// Grandchild under Workbench
+	require.NoError(
+		t,
+		db.CreateLocation(ctx, f.drawer1ID, fmt.Sprintf("Drawer1-%s", prefix), &f.workbenchID, false, 0, ts),
+	)
+
+	// Items
+	require.NoError(t, db.CreateItem(ctx, f.item1ID, "drill", f.garageID, 1, ts))
+	require.NoError(t, db.CreateItem(ctx, f.item2ID, "hammer", f.garageID, 2, ts))
+	require.NoError(t, db.CreateItem(ctx, f.item3ID, "sandpaper", f.shelfAID, 3, ts))
+	require.NoError(t, db.CreateItem(ctx, f.item4ID, "chisel", f.workbenchID, 4, ts))
+	require.NoError(t, db.CreateItem(ctx, f.item5ID, "screwdriver", f.missingID, 5, ts))
+
+	t.Cleanup(func() { db.Close() })
+
+	return f
+}
+
+// ---- buildLocationNodeFlat tests ----
+
+func TestBuildLocationNodeFlat_ItemsPopulated(t *testing.T) {
+	f := setupListTest(t)
+
+	garage, err := f.db.GetLocation(f.ctx, f.garageID)
+	require.NoError(t, err)
+
+	node, err := buildLocationNodeFlat(f.ctx, f.db, garage)
+	require.NoError(t, err)
+	require.NotNil(t, node)
+
+	assert.Len(t, node.Items, 2)
+	assert.Equal(t, "drill", node.Items[0].DisplayName)
+	assert.Equal(t, "hammer", node.Items[1].DisplayName)
+}
+
+func TestBuildLocationNodeFlat_ChildrenAreHintOnly(t *testing.T) {
+	f := setupListTest(t)
+
+	garage, err := f.db.GetLocation(f.ctx, f.garageID)
+	require.NoError(t, err)
+
+	node, err := buildLocationNodeFlat(f.ctx, f.db, garage)
+	require.NoError(t, err)
+
+	// Two children: ShelfA and Workbench
+	assert.Len(t, node.Children, 2)
+
+	for _, child := range node.Children {
+		// Hint nodes have nil Items and nil Children slices.
+		assert.Nil(t, child.Items, "flat child should not have Items populated")
+		assert.Nil(t, child.Children, "flat child should not have Children populated")
+		// But should have count metadata.
+		assert.GreaterOrEqual(t, child.ChildItemCount, 0)
+		assert.GreaterOrEqual(t, child.ChildLocationCount, 0)
+	}
+}
+
+func TestBuildLocationNodeFlat_ChildItemAndLocationCounts(t *testing.T) {
+	f := setupListTest(t)
+
+	garage, err := f.db.GetLocation(f.ctx, f.garageID)
+	require.NoError(t, err)
+
+	node, err := buildLocationNodeFlat(f.ctx, f.db, garage)
+	require.NoError(t, err)
+
+	// Find ShelfA hint: 1 item, 0 locations.
+	var shelfHint, workbenchHint *LocationNode
+	for _, child := range node.Children {
+		if child.Location.LocationID == f.shelfAID {
+			shelfHint = child
+		}
+		if child.Location.LocationID == f.workbenchID {
+			workbenchHint = child
+		}
+	}
+
+	require.NotNil(t, shelfHint, "ShelfA hint missing")
+	assert.Equal(t, 1, shelfHint.ChildItemCount)
+	assert.Equal(t, 0, shelfHint.ChildLocationCount)
+
+	require.NotNil(t, workbenchHint, "Workbench hint missing")
+	assert.Equal(t, 1, workbenchHint.ChildItemCount)
+	assert.Equal(t, 1, workbenchHint.ChildLocationCount)
+}
+
+func TestBuildLocationNodeFlat_EmptyLocation(t *testing.T) {
+	f := setupListTest(t)
+
+	office, err := f.db.GetLocation(f.ctx, f.officeID)
+	require.NoError(t, err)
+
+	node, err := buildLocationNodeFlat(f.ctx, f.db, office)
+	require.NoError(t, err)
+
+	assert.Empty(t, node.Items)
+	assert.Empty(t, node.Children)
+}
+
+// ---- buildLocationNodeRecursive tests ----
+
+func TestBuildLocationNodeRecursive_FullTree(t *testing.T) {
+	f := setupListTest(t)
+
+	garage, err := f.db.GetLocation(f.ctx, f.garageID)
+	require.NoError(t, err)
+
+	node, err := buildLocationNodeRecursive(f.ctx, f.db, garage)
+	require.NoError(t, err)
+
+	// Garage: 2 items, 2 children
+	assert.Len(t, node.Items, 2)
+	assert.Len(t, node.Children, 2)
+
+	// Find Workbench child
+	var workbench *LocationNode
+	for _, child := range node.Children {
+		if child.Location.LocationID == f.workbenchID {
+			workbench = child
+		}
+	}
+	require.NotNil(t, workbench)
+
+	// Workbench: 1 item, 1 child (Drawer1)
+	assert.Len(t, workbench.Items, 1)
+	assert.Len(t, workbench.Children, 1)
+
+	// Drawer1: 0 items, 0 children
+	drawer1 := workbench.Children[0]
+	assert.Empty(t, drawer1.Items)
+	assert.Empty(t, drawer1.Children)
+}
+
+func TestBuildLocationNodeRecursive_EmptyLocation(t *testing.T) {
+	f := setupListTest(t)
+
+	office, err := f.db.GetLocation(f.ctx, f.officeID)
+	require.NoError(t, err)
+
+	node, err := buildLocationNodeRecursive(f.ctx, f.db, office)
+	require.NoError(t, err)
+
+	// Zero items, zero children.
+	assert.Empty(t, node.Items)
+	assert.Empty(t, node.Children)
+}
+
+// ---- buildNodes tests ----
+
+func TestBuildNodes_NoArgs_UsesRoots(t *testing.T) {
+	f := setupListTest(t)
+
+	nodes, err := buildNodes(f.ctx, f.db, nil, false)
+	require.NoError(t, err)
+	// Should include Garage, Office, Missing (all roots).
+	assert.GreaterOrEqual(t, len(nodes), 3)
+	for _, n := range nodes {
+		assert.False(t, n.NotFound)
+	}
+}
+
+func TestBuildNodes_UnknownArg_NotFoundNode(t *testing.T) {
+	f := setupListTest(t)
+
+	nodes, err := buildNodes(f.ctx, f.db, []string{"DoesNotExist-xyz"}, false)
+	require.NoError(t, err) // not-found does not cause an error
+	require.Len(t, nodes, 1)
+	assert.True(t, nodes[0].NotFound)
+	assert.Equal(t, "DoesNotExist-xyz", nodes[0].InputArg)
+}
+
+func TestBuildNodes_MixedArgs_SomeFound(t *testing.T) {
+	f := setupListTest(t)
+
+	garage, err := f.db.GetLocation(f.ctx, f.garageID)
+	require.NoError(t, err)
+
+	nodes, err := buildNodes(f.ctx, f.db, []string{garage.CanonicalName, "NoSuchPlace"}, false)
+	require.NoError(t, err)
+	require.Len(t, nodes, 2)
+
+	assert.False(t, nodes[0].NotFound)
+	assert.True(t, nodes[1].NotFound)
+	assert.Equal(t, "NoSuchPlace", nodes[1].InputArg)
+}
+
+func TestBuildNodes_Recurse_FullTree(t *testing.T) {
+	f := setupListTest(t)
+
+	garage, err := f.db.GetLocation(f.ctx, f.garageID)
+	require.NoError(t, err)
+
+	nodes, err := buildNodes(f.ctx, f.db, []string{garage.CanonicalName}, true)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	garageNode := nodes[0]
+	assert.Len(t, garageNode.Children, 2)
+	// Children should have their own Items populated (recursive mode).
+	for _, child := range garageNode.Children {
+		assert.NotNil(t, child.Items)
+	}
+}
+
+// ---- JSON output tests ----
+
+func TestToJSON_NotFoundNode(t *testing.T) {
+	nodes := []*LocationNode{
+		{NotFound: true, InputArg: "ghost"},
+	}
+	out := toJSON(nodes)
+	require.Len(t, out.Locations, 1)
+	assert.True(t, out.Locations[0].NotFound)
+	assert.Equal(t, "ghost", out.Locations[0].DisplayName)
+}
+
+func TestToJSON_SingleLocation(t *testing.T) {
+	f := setupListTest(t)
+
+	garage, err := f.db.GetLocation(f.ctx, f.garageID)
+	require.NoError(t, err)
+
+	node, err := buildLocationNodeFlat(f.ctx, f.db, garage)
+	require.NoError(t, err)
+
+	out := toJSON([]*LocationNode{node})
+	require.Len(t, out.Locations, 1)
+
+	loc := out.Locations[0]
+	assert.Equal(t, f.garageID, loc.LocationID)
+	assert.Equal(t, 2, loc.ItemCount)
+	assert.Equal(t, 2, loc.LocationCount)
+	assert.Len(t, loc.Items, 2)
+	assert.Len(t, loc.Children, 2)
+}
+
+func TestToJSON_JSONRoundtrip(t *testing.T) {
+	f := setupListTest(t)
+
+	garage, err := f.db.GetLocation(f.ctx, f.garageID)
+	require.NoError(t, err)
+
+	node, err := buildLocationNodeRecursive(f.ctx, f.db, garage)
+	require.NoError(t, err)
+
+	out := toJSON([]*LocationNode{node})
+
+	data, marshalErr := json.Marshal(out)
+	require.NoError(t, marshalErr)
+
+	var back OutputJSON
+	require.NoError(t, json.Unmarshal(data, &back))
+
+	assert.Equal(t, out.Locations[0].LocationID, back.Locations[0].LocationID)
+	assert.Equal(t, out.Locations[0].ItemCount, back.Locations[0].ItemCount)
+}
+
+// ---- renderTree tests ----
+
+func TestRenderTree_EmptyNodes(t *testing.T) {
+	var buf bytes.Buffer
+	renderTree(&buf, nil)
+	assert.Empty(t, buf.String())
+}
+
+func TestRenderTree_NotFoundNode(t *testing.T) {
+	var buf bytes.Buffer
+	renderTree(&buf, []*LocationNode{{NotFound: true, InputArg: "old-shelf"}})
+	assert.Equal(t, "old-shelf [not found]\n", buf.String())
+}
+
+func TestRenderTree_SingleLocationNoItems(t *testing.T) {
+	loc := &database.Location{DisplayName: "Office", LocationID: "id-office"}
+	node := &LocationNode{
+		Location: loc,
+		Items:    []*database.Item{},
+		Children: []*LocationNode{},
+	}
+
+	var buf bytes.Buffer
+	renderTree(&buf, []*LocationNode{node})
+
+	output := buf.String()
+	assert.Contains(t, output, "Office (0 items, 0 locations)")
+}
+
+func TestRenderTree_ItemsShownWithConnectors(t *testing.T) {
+	loc := &database.Location{DisplayName: "Garage", LocationID: "id-garage"}
+	node := &LocationNode{
+		Location: loc,
+		Items: []*database.Item{
+			{DisplayName: "drill"},
+			{DisplayName: "hammer"},
+		},
+		Children: []*LocationNode{},
+	}
+
+	var buf bytes.Buffer
+	renderTree(&buf, []*LocationNode{node})
+
+	output := buf.String()
+	assert.Contains(t, output, "drill")
+	assert.Contains(t, output, "hammer")
+	// treeprint uses box-drawing characters for connectors
+	assert.Contains(t, output, "└──")
+}
+
+func TestRenderTree_TemporaryUseItemHasStar(t *testing.T) {
+	loc := &database.Location{DisplayName: "Garage", LocationID: "id-garage"}
+	node := &LocationNode{
+		Location: loc,
+		Items: []*database.Item{
+			{DisplayName: "drill", InTemporaryUse: true},
+		},
+		Children: []*LocationNode{},
+	}
+
+	var buf bytes.Buffer
+	renderTree(&buf, []*LocationNode{node})
+
+	output := buf.String()
+	assert.Contains(t, output, "drill *")
+}
+
+func TestRenderTree_FlatChildHints(t *testing.T) {
+	loc := &database.Location{DisplayName: "Garage", LocationID: "id-garage"}
+	shelfLoc := &database.Location{DisplayName: "Shelf A", LocationID: "id-shelf"}
+	node := &LocationNode{
+		Location: loc,
+		Items:    []*database.Item{},
+		Children: []*LocationNode{
+			{
+				Location:           shelfLoc,
+				ChildItemCount:     1,
+				ChildLocationCount: 3,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	renderTree(&buf, []*LocationNode{node})
+
+	output := buf.String()
+	assert.Contains(t, output, "[Shelf A]")
+	assert.Contains(t, output, "1 item")
+	assert.Contains(t, output, "3 locations")
+}
+
+func TestRenderTree_MultipleRootsSeparatedByBlankLines(t *testing.T) {
+	loc1 := &database.Location{DisplayName: "Garage", LocationID: "id-1"}
+	loc2 := &database.Location{DisplayName: "Office", LocationID: "id-2"}
+
+	nodes := []*LocationNode{
+		{Location: loc1, Items: []*database.Item{}, Children: []*LocationNode{}},
+		{Location: loc2, Items: []*database.Item{}, Children: []*LocationNode{}},
+	}
+
+	var buf bytes.Buffer
+	renderTree(&buf, nodes)
+
+	output := buf.String()
+	// Blank line between the two trees
+	assert.Contains(t, output, "\n\n")
+	assert.Contains(t, output, "Garage")
+	assert.Contains(t, output, "Office")
+}
+
+func TestRenderTree_PluralSingular(t *testing.T) {
+	loc := &database.Location{DisplayName: "Test", LocationID: "id-test"}
+	child := &database.Location{DisplayName: "Sub", LocationID: "id-sub"}
+	node := &LocationNode{
+		Location: loc,
+		Items:    []*database.Item{{DisplayName: "widget"}},
+		Children: []*LocationNode{
+			{
+				Location:           child,
+				ChildItemCount:     1,
+				ChildLocationCount: 1,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	renderTree(&buf, []*LocationNode{node})
+
+	output := buf.String()
+	// Header: "1 item" (not "1 items")
+	assert.Contains(t, output, "1 item,")
+	// Sub-location hint: "1 item, 1 location"
+	assert.Contains(t, output, "1 location")
+	// Ensure "items" plural is NOT used for count of 1
+	lines := strings.SplitSeq(output, "\n")
+	for line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "Test") {
+			assert.NotContains(t, line, "1 items")
+		}
+	}
+}
+
+func TestRenderTree_RecursiveTree(t *testing.T) {
+	f := setupListTest(t)
+
+	garage, err := f.db.GetLocation(f.ctx, f.garageID)
+	require.NoError(t, err)
+
+	node, err := buildLocationNodeRecursive(f.ctx, f.db, garage)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	renderTree(&buf, []*LocationNode{node})
+
+	output := buf.String()
+	assert.Contains(t, output, "drill")
+	assert.Contains(t, output, "hammer")
+	assert.Contains(t, output, "sandpaper")
+	assert.Contains(t, output, "chisel")
+}
+
+// ---- locationHeader unit tests ----
+
+func TestLocationHeader_NoItemsNoLocations(t *testing.T) {
+	result := locationHeader("Office", 0, 0)
+	assert.Equal(t, "Office (0 items, 0 locations)", result)
+}
+
+func TestLocationHeader_SingleItemNoLocations(t *testing.T) {
+	result := locationHeader("Shelf", 1, 0)
+	assert.Equal(t, "Shelf (1 item, 0 locations)", result)
+}
+
+func TestLocationHeader_MultipleItemsNoLocations(t *testing.T) {
+	result := locationHeader("Garage", 2, 0)
+	assert.Equal(t, "Garage (2 items, 0 locations)", result)
+}
+
+func TestLocationHeader_NoItemsSingleLocation(t *testing.T) {
+	result := locationHeader("Cabinet", 0, 1)
+	assert.Equal(t, "Cabinet (0 items, 1 location)", result)
+}
+
+func TestLocationHeader_NoItemsMultipleLocations(t *testing.T) {
+	result := locationHeader("Workshop", 0, 3)
+	assert.Equal(t, "Workshop (0 items, 3 locations)", result)
+}
+
+func TestLocationHeader_MultipleItemsAndLocations(t *testing.T) {
+	result := locationHeader("Basement", 5, 2)
+	assert.Equal(t, "Basement (5 items, 2 locations)", result)
+}
+
+// ---- runList integration tests ----
+
+func TestRunList_NoArgs_ShowsAllRootLocations(t *testing.T) {
+	f := setupListTest(t)
+
+	// Fetch expected location names before closing database
+	garage, _ := f.db.GetLocation(f.ctx, f.garageID)
+	office, _ := f.db.GetLocation(f.ctx, f.officeID)
+	missing, _ := f.db.GetLocation(f.ctx, f.missingID)
+
+	require.NotNil(t, garage)
+	require.NotNil(t, office)
+	require.NotNil(t, missing)
+
+	garageDisplayName := garage.DisplayName
+	officeDisplayName := office.DisplayName
+	missingDisplayName := missing.DisplayName
+
+	var buf bytes.Buffer
+	cmd := GetListCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{})
+
+	// Create context with a background parent (not nil)
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, testDatabaseKey, f.db)
+	testCfg := &config.Config{
+		Output: config.OutputConfig{DefaultFormat: "text"},
+	}
+	ctx = context.WithValue(ctx, testConfigKey, testCfg)
+	cmd.SetContext(ctx)
+
+	// Override openDatabase to use injected DB
+	testOpenDatabase = func(ctx context.Context) (*database.Database, error) {
+		if db, ok := ctx.Value(testDatabaseKey).(*database.Database); ok {
+			return db, nil
+		}
+		return nil, errors.New("database not found in context")
+	}
+	defer func() { testOpenDatabase = nil }()
+
+	// Override cli.MustGetConfig to use injected config
+	testMustGetConfig = func(ctx context.Context) *config.Config {
+		if cfg, ok := ctx.Value(testConfigKey).(*config.Config); ok {
+			return cfg
+		}
+		return &config.Config{
+			Output: config.OutputConfig{DefaultFormat: "text"},
+		}
+	}
+	defer func() { testMustGetConfig = nil }()
+
+	err := runList(cmd, []string{})
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, garageDisplayName)
+	assert.Contains(t, output, officeDisplayName)
+	assert.Contains(t, output, missingDisplayName)
+}
+
+func TestRunList_SingleArgFound_ShowsLocationItems(t *testing.T) {
+	f := setupListTest(t)
+
+	garage, _ := f.db.GetLocation(f.ctx, f.garageID)
+	require.NotNil(t, garage)
+
+	garageCanonicalName := garage.CanonicalName
+	garageDisplayName := garage.DisplayName
+
+	var buf bytes.Buffer
+	cmd := GetListCmd()
+	cmd.SetOut(&buf)
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, testDatabaseKey, f.db)
+	testCfg := &config.Config{
+		Output: config.OutputConfig{DefaultFormat: "text"},
+	}
+	ctx = context.WithValue(ctx, testConfigKey, testCfg)
+	cmd.SetContext(ctx)
+
+	testOpenDatabase = func(ctx context.Context) (*database.Database, error) {
+		if db, ok := ctx.Value(testDatabaseKey).(*database.Database); ok {
+			return db, nil
+		}
+		return nil, errors.New("database not found in context")
+	}
+	defer func() { testOpenDatabase = nil }()
+
+	testMustGetConfig = func(ctx context.Context) *config.Config {
+		if cfg, ok := ctx.Value(testConfigKey).(*config.Config); ok {
+			return cfg
+		}
+		return &config.Config{
+			Output: config.OutputConfig{DefaultFormat: "text"},
+		}
+	}
+	defer func() { testMustGetConfig = nil }()
+
+	err := runList(cmd, []string{garageCanonicalName})
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, garageDisplayName)
+	assert.Contains(t, output, "drill")
+	assert.Contains(t, output, "hammer")
+}
+
+func TestRunList_SingleArgNotFound_RendersNotFound(t *testing.T) {
+	f := setupListTest(t)
+
+	var buf bytes.Buffer
+	cmd := GetListCmd()
+	cmd.SetOut(&buf)
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, testDatabaseKey, f.db)
+	testCfg := &config.Config{
+		Output: config.OutputConfig{DefaultFormat: "text"},
+	}
+	ctx = context.WithValue(ctx, testConfigKey, testCfg)
+	cmd.SetContext(ctx)
+
+	testOpenDatabase = func(ctx context.Context) (*database.Database, error) {
+		if db, ok := ctx.Value(testDatabaseKey).(*database.Database); ok {
+			return db, nil
+		}
+		return nil, errors.New("database not found in context")
+	}
+	defer func() { testOpenDatabase = nil }()
+
+	testMustGetConfig = func(ctx context.Context) *config.Config {
+		if cfg, ok := ctx.Value(testConfigKey).(*config.Config); ok {
+			return cfg
+		}
+		return &config.Config{
+			Output: config.OutputConfig{DefaultFormat: "text"},
+		}
+	}
+	defer func() { testMustGetConfig = nil }()
+
+	err := runList(cmd, []string{"does_not_exist"})
+	require.NoError(t, err) // no error on not-found
+
+	output := buf.String()
+	assert.Contains(t, output, "does_not_exist [not found]")
+}
+
+func TestRunList_MixedArgsBothRender(t *testing.T) {
+	f := setupListTest(t)
+
+	garage, _ := f.db.GetLocation(f.ctx, f.garageID)
+	require.NotNil(t, garage)
+
+	garageCanonicalName := garage.CanonicalName
+	garageDisplayName := garage.DisplayName
+
+	var buf bytes.Buffer
+	cmd := GetListCmd()
+	cmd.SetOut(&buf)
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, testDatabaseKey, f.db)
+	testCfg := &config.Config{
+		Output: config.OutputConfig{DefaultFormat: "text"},
+	}
+	ctx = context.WithValue(ctx, testConfigKey, testCfg)
+	cmd.SetContext(ctx)
+
+	testOpenDatabase = func(ctx context.Context) (*database.Database, error) {
+		if db, ok := ctx.Value(testDatabaseKey).(*database.Database); ok {
+			return db, nil
+		}
+		return nil, errors.New("database not found in context")
+	}
+	defer func() { testOpenDatabase = nil }()
+
+	testMustGetConfig = func(ctx context.Context) *config.Config {
+		if cfg, ok := ctx.Value(testConfigKey).(*config.Config); ok {
+			return cfg
+		}
+		return &config.Config{
+			Output: config.OutputConfig{DefaultFormat: "text"},
+		}
+	}
+	defer func() { testMustGetConfig = nil }()
+
+	err := runList(cmd, []string{garageCanonicalName, "ghost_location"})
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, garageDisplayName)
+	assert.Contains(t, output, "drill")
+	assert.Contains(t, output, "ghost_location [not found]")
+}
+
+func TestRunList_RecurseFlag_IncludesSublocationsRecursively(t *testing.T) {
+	f := setupListTest(t)
+
+	garage, _ := f.db.GetLocation(f.ctx, f.garageID)
+	require.NotNil(t, garage)
+
+	garageDisplayName := garage.DisplayName
+
+	var buf bytes.Buffer
+	cmd := GetListCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--recurse"})
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, testDatabaseKey, f.db)
+	testCfg := &config.Config{
+		Output: config.OutputConfig{DefaultFormat: "text"},
+	}
+	ctx = context.WithValue(ctx, testConfigKey, testCfg)
+	cmd.SetContext(ctx)
+
+	testOpenDatabase = func(ctx context.Context) (*database.Database, error) {
+		if db, ok := ctx.Value(testDatabaseKey).(*database.Database); ok {
+			return db, nil
+		}
+		return nil, errors.New("database not found in context")
+	}
+	defer func() { testOpenDatabase = nil }()
+
+	testMustGetConfig = func(ctx context.Context) *config.Config {
+		if cfg, ok := ctx.Value(testConfigKey).(*config.Config); ok {
+			return cfg
+		}
+		return &config.Config{
+			Output: config.OutputConfig{DefaultFormat: "text"},
+		}
+	}
+	defer func() { testMustGetConfig = nil }()
+
+	// Must call with the correct args to GetListCmd
+	err := cmd.ExecuteContext(ctx)
+	require.NoError(t, err)
+
+	output := buf.String()
+	// In recursive mode, should show items from grandchild (Drawer1 is a child of Workbench)
+	assert.Contains(t, output, garageDisplayName)
+	assert.Contains(t, output, "drill")
+	assert.Contains(t, output, "hammer")
+	assert.Contains(t, output, "sandpaper") // from ShelfA
+	assert.Contains(t, output, "chisel")    // from Workbench
+}
+
+func TestRunList_JSONFlag_OutputsValidJSON(t *testing.T) {
+	f := setupListTest(t)
+
+	garage, _ := f.db.GetLocation(f.ctx, f.garageID)
+	require.NotNil(t, garage)
+
+	garageID := garage.LocationID
+	garageCanonicalName := garage.CanonicalName
+
+	var buf bytes.Buffer
+	cmd := GetListCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{garageCanonicalName})
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, testDatabaseKey, f.db)
+	testCfg := &config.Config{
+		Output: config.OutputConfig{DefaultFormat: "json"},
+	}
+	ctx = context.WithValue(ctx, testConfigKey, testCfg)
+	cmd.SetContext(ctx)
+
+	testOpenDatabase = func(ctx context.Context) (*database.Database, error) {
+		if db, ok := ctx.Value(testDatabaseKey).(*database.Database); ok {
+			return db, nil
+		}
+		return nil, errors.New("database not found in context")
+	}
+	defer func() { testOpenDatabase = nil }()
+
+	testMustGetConfig = func(ctx context.Context) *config.Config {
+		if cfg, ok := ctx.Value(testConfigKey).(*config.Config); ok {
+			return cfg
+		}
+		return &config.Config{
+			Output: config.OutputConfig{DefaultFormat: "json"},
+		}
+	}
+	defer func() { testMustGetConfig = nil }()
+
+	err := cmd.ExecuteContext(ctx)
+	require.NoError(t, err)
+
+	// Verify output is valid JSON
+	var result OutputJSON
+	err = json.Unmarshal(buf.Bytes(), &result)
+	require.NoError(t, err)
+
+	require.Len(t, result.Locations, 1)
+	assert.Equal(t, garageID, result.Locations[0].LocationID)
+	assert.Equal(t, 2, result.Locations[0].ItemCount)
+	assert.Equal(t, 2, result.Locations[0].LocationCount)
+}
+
+func TestRunList_JSONWithNotFound_IncludesNotFoundMarker(t *testing.T) {
+	f := setupListTest(t)
+
+	garage, _ := f.db.GetLocation(f.ctx, f.garageID)
+	require.NotNil(t, garage)
+
+	garageCanonicalName := garage.CanonicalName
+
+	var buf bytes.Buffer
+	cmd := GetListCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{garageCanonicalName, "nonexistent_location"})
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, testDatabaseKey, f.db)
+	testCfg := &config.Config{
+		Output: config.OutputConfig{DefaultFormat: "json"},
+	}
+	ctx = context.WithValue(ctx, testConfigKey, testCfg)
+	cmd.SetContext(ctx)
+
+	testOpenDatabase = func(ctx context.Context) (*database.Database, error) {
+		if db, ok := ctx.Value(testDatabaseKey).(*database.Database); ok {
+			return db, nil
+		}
+		return nil, errors.New("database not found in context")
+	}
+	defer func() { testOpenDatabase = nil }()
+
+	testMustGetConfig = func(ctx context.Context) *config.Config {
+		if cfg, ok := ctx.Value(testConfigKey).(*config.Config); ok {
+			return cfg
+		}
+		return &config.Config{
+			Output: config.OutputConfig{DefaultFormat: "json"},
+		}
+	}
+	defer func() { testMustGetConfig = nil }()
+
+	err := cmd.ExecuteContext(ctx)
+	require.NoError(t, err)
+
+	var result OutputJSON
+	err = json.Unmarshal(buf.Bytes(), &result)
+	require.NoError(t, err)
+
+	// Should have 2 locations: one found, one not found
+	require.Len(t, result.Locations, 2)
+	assert.False(t, result.Locations[0].NotFound)
+	assert.True(t, result.Locations[1].NotFound)
+	assert.Equal(t, "nonexistent_location", result.Locations[1].DisplayName)
+}
+
+// Test helpers for dependency injection
+
+type testDatabaseKeyType string
+type testConfigKeyType string
+
+const (
+	testDatabaseKey testDatabaseKeyType = "testDatabase"
+	testConfigKey   testConfigKeyType   = "testConfig"
+)

--- a/cmd/list/output.go
+++ b/cmd/list/output.go
@@ -1,0 +1,200 @@
+package list
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/dustin/go-humanize/english"
+	"github.com/xlab/treeprint"
+
+	"github.com/asphaltbuffet/wherehouse/internal/database"
+)
+
+// LocationNode is one node in the rendered tree.
+//
+// In non-recursive mode, Children are populated with hint-only nodes
+// (Items and Children are nil; ChildItemCount and ChildLocationCount are set).
+// In recursive mode, Items and Children are fully populated;
+// ChildItemCount and ChildLocationCount are unused (derive from len).
+type LocationNode struct {
+	Location           *database.Location
+	Items              []*database.Item // direct items (alphabetical)
+	Children           []*LocationNode  // sub-locations (alphabetical by display_name)
+	ChildItemCount     int              // hint nodes only: item count for this location
+	ChildLocationCount int              // hint nodes only: direct child location count
+	NotFound           bool             // true if this node represents an unresolved arg
+	InputArg           string           // original input argument, used when NotFound=true
+}
+
+// ItemJSON is the JSON representation of a single item.
+type ItemJSON struct {
+	ItemID         string  `json:"item_id"`
+	DisplayName    string  `json:"display_name"`
+	CanonicalName  string  `json:"canonical_name"`
+	InTemporaryUse bool    `json:"in_temporary_use"`
+	ProjectID      *string `json:"project_id"`
+}
+
+// LocationJSON is the JSON representation of a location with its contents.
+type LocationJSON struct {
+	LocationID      string         `json:"location_id"`
+	DisplayName     string         `json:"display_name"`
+	CanonicalName   string         `json:"canonical_name"`
+	FullPathDisplay string         `json:"full_path_display"`
+	IsSystem        bool           `json:"is_system"`
+	ItemCount       int            `json:"item_count"`
+	LocationCount   int            `json:"location_count"`
+	Items           []ItemJSON     `json:"items"`
+	Children        []LocationJSON `json:"children"`
+	NotFound        bool           `json:"not_found,omitempty"`
+}
+
+// OutputJSON is the top-level JSON output structure.
+type OutputJSON struct {
+	Locations []LocationJSON `json:"locations"`
+}
+
+// locationHeader returns the formatted display string for a location node header.
+// e.g. "Garage (3 items, 2 locations)" or "Office (0 items, 0 locations)".
+func locationHeader(name string, itemCount, locationCount int) string {
+	return fmt.Sprintf("%s (%d %s, %d %s)",
+		name,
+		itemCount, english.PluralWord(itemCount, "item", ""),
+		locationCount, english.PluralWord(locationCount, "location", ""),
+	)
+}
+
+// populateTree adds the items and child sub-locations from node into branch.
+// Items appear before sub-locations; both groups are already in alphabetical
+// order from the database queries.
+func populateTree(branch treeprint.Tree, node *LocationNode) {
+	// Items first (already alphabetical from DB)
+	for _, item := range node.Items {
+		label := item.DisplayName
+		if item.InTemporaryUse {
+			label += " *"
+		}
+		branch.AddNode(label)
+	}
+
+	// Sub-locations
+	for _, child := range node.Children {
+		if child.NotFound {
+			// Guard: not-found nodes should not appear as children, but handle defensively.
+			branch.AddNode(child.InputArg + " [not found]")
+			continue
+		}
+
+		// Determine counts for this child.
+		var childItems, childLocs int
+		// Flat hint nodes have both Items and Children as nil (only ChildItemCount/ChildLocationCount set).
+		// Recursive nodes always have non-nil Children (make(...) in buildLocationNodeRecursive ensures this
+		// even for empty slices), so this nil check reliably distinguishes the two modes.
+		if child.Items != nil || child.Children != nil {
+			// Recursive mode: derive from populated slices.
+			childItems = len(child.Items)
+			childLocs = len(child.Children)
+		} else {
+			// Flat mode: use pre-fetched counts.
+			childItems = child.ChildItemCount
+			childLocs = child.ChildLocationCount
+		}
+
+		header := "[" + child.Location.DisplayName + "] " +
+			fmt.Sprintf("(%d %s, %d %s)",
+				childItems, english.PluralWord(childItems, "item", ""),
+				childLocs, english.PluralWord(childLocs, "location", ""),
+			)
+		childBranch := branch.AddBranch(header)
+
+		// Only recurse if fully built (recursive mode).
+		if child.Items != nil || child.Children != nil {
+			populateTree(childBranch, child)
+		}
+	}
+}
+
+// renderTree renders a slice of root LocationNodes to w, one tree per root.
+// Roots are separated by blank lines.
+func renderTree(w io.Writer, nodes []*LocationNode) {
+	for i, node := range nodes {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+
+		if node.NotFound {
+			fmt.Fprintln(w, node.InputArg+" [not found]")
+			continue
+		}
+
+		// Determine item and location counts for the root node header.
+		itemCount := len(node.Items)
+		locCount := len(node.Children)
+
+		// In flat mode, Items/Children may be nil but counts are in the hint fields.
+		if node.Items == nil && node.Children == nil {
+			itemCount = node.ChildItemCount
+			locCount = node.ChildLocationCount
+		}
+
+		root := treeprint.New()
+		root.SetValue(locationHeader(node.Location.DisplayName, itemCount, locCount))
+		populateTree(root, node)
+		fmt.Fprint(w, root.String())
+	}
+}
+
+// toJSON converts a slice of LocationNodes to the OutputJSON structure.
+func toJSON(nodes []*LocationNode) OutputJSON {
+	locs := make([]LocationJSON, 0, len(nodes))
+	for _, node := range nodes {
+		locs = append(locs, nodeToJSON(node))
+	}
+	return OutputJSON{Locations: locs}
+}
+
+// nodeToJSON converts a single LocationNode to its JSON representation.
+func nodeToJSON(node *LocationNode) LocationJSON {
+	if node.NotFound {
+		return LocationJSON{
+			DisplayName: node.InputArg,
+			NotFound:    true,
+		}
+	}
+
+	itemCount := len(node.Items)
+	locCount := len(node.Children)
+	if node.Items == nil && node.Children == nil {
+		itemCount = node.ChildItemCount
+		locCount = node.ChildLocationCount
+	}
+
+	items := make([]ItemJSON, 0, len(node.Items))
+	for _, item := range node.Items {
+		j := ItemJSON{
+			ItemID:         item.ItemID,
+			DisplayName:    item.DisplayName,
+			CanonicalName:  item.CanonicalName,
+			InTemporaryUse: item.InTemporaryUse,
+			ProjectID:      item.ProjectID,
+		}
+		items = append(items, j)
+	}
+
+	children := make([]LocationJSON, 0, len(node.Children))
+	for _, child := range node.Children {
+		children = append(children, nodeToJSON(child))
+	}
+
+	return LocationJSON{
+		LocationID:      node.Location.LocationID,
+		DisplayName:     node.Location.DisplayName,
+		CanonicalName:   node.Location.CanonicalName,
+		FullPathDisplay: node.Location.FullPathDisplay,
+		IsSystem:        node.Location.IsSystem,
+		ItemCount:       itemCount,
+		LocationCount:   locCount,
+		Items:           items,
+		Children:        children,
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/asphaltbuffet/wherehouse/cmd/find"
 	"github.com/asphaltbuffet/wherehouse/cmd/history"
 	"github.com/asphaltbuffet/wherehouse/cmd/initialize"
+	listcmd "github.com/asphaltbuffet/wherehouse/cmd/list"
 	"github.com/asphaltbuffet/wherehouse/cmd/loan"
 	"github.com/asphaltbuffet/wherehouse/cmd/lost"
 	"github.com/asphaltbuffet/wherehouse/cmd/move"
@@ -63,6 +64,7 @@ Examples:
 	rootCmd.AddCommand(find.GetFindCmd())
 	rootCmd.AddCommand(history.GetHistoryCmd())
 	rootCmd.AddCommand(initialize.GetInitializeCmd())
+	rootCmd.AddCommand(listcmd.GetListCmd())
 	rootCmd.AddCommand(loan.GetLoanCmd())
 	rootCmd.AddCommand(lost.GetLostCmd())
 	rootCmd.AddCommand(move.GetMoveCmd())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	configpkg "github.com/asphaltbuffet/wherehouse/cmd/config"
 	"github.com/asphaltbuffet/wherehouse/cmd/find"
 	"github.com/asphaltbuffet/wherehouse/cmd/history"
+	"github.com/asphaltbuffet/wherehouse/cmd/initialize"
 	"github.com/asphaltbuffet/wherehouse/cmd/loan"
 	"github.com/asphaltbuffet/wherehouse/cmd/lost"
 	"github.com/asphaltbuffet/wherehouse/cmd/move"
@@ -61,6 +62,7 @@ Examples:
 	rootCmd.AddCommand(add.GetAddCmd())
 	rootCmd.AddCommand(find.GetFindCmd())
 	rootCmd.AddCommand(history.GetHistoryCmd())
+	rootCmd.AddCommand(initialize.GetInitializeCmd())
 	rootCmd.AddCommand(loan.GetLoanCmd())
 	rootCmd.AddCommand(lost.GetLostCmd())
 	rootCmd.AddCommand(move.GetMoveCmd())

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	github.com/xlab/treeprint v1.2.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	modernc.org/sqlite v1.46.1
 )

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
+github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -136,6 +136,9 @@ schema = 3
   [mod."github.com/subosito/gotenv"]
     version = "v1.6.0"
     hash = "sha256-LspbjTniiq2xAICSXmgqP7carwlNaLqnCTQfw2pa80A="
+  [mod."github.com/xlab/treeprint"]
+    version = "v1.2.0"
+    hash = "sha256-g85HyWGLZuD/TFXZzmXT+u9TA1xIT5escUVhnofsYQI="
   [mod."github.com/xo/terminfo"]
     version = "v0.0.0-20220910002029-abceb7e1c41e"
     hash = "sha256-GyCDxxMQhXA3Pi/TsWXpA8cX5akEoZV7CFx4RO3rARU="

--- a/internal/cli/database.go
+++ b/internal/cli/database.go
@@ -4,10 +4,28 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/asphaltbuffet/wherehouse/internal/config"
 	"github.com/asphaltbuffet/wherehouse/internal/database"
 )
+
+// ErrDatabaseNotInitialized is returned when the database file does not exist on disk.
+// Callers can use [errors.Is] to detect this case programmatically.
+var ErrDatabaseNotInitialized = errors.New("database not initialized")
+
+// CheckDatabaseExists returns ErrDatabaseNotInitialized if the file at dbPath
+// does not exist. Returns nil if the file is present. Returns a wrapped os error
+// for any other stat failure (permissions, etc.).
+func CheckDatabaseExists(dbPath string) error {
+	_, err := os.Stat(dbPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("database not found at %q: run `wherehouse initialize database` to create it: %w",
+			dbPath, ErrDatabaseNotInitialized)
+	}
+
+	return err // nil or unexpected OS error
+}
 
 // OpenDatabase opens the database connection using config settings.
 // It extracts the database path from the context config and opens
@@ -16,6 +34,7 @@ import (
 // Returns an error if:
 //   - Configuration is not found in context
 //   - Database path cannot be resolved
+//   - Database file does not exist (use `wherehouse initialize database` to create it)
 //   - Database connection fails
 func OpenDatabase(ctx context.Context) (*database.Database, error) {
 	// Get config from context
@@ -28,6 +47,11 @@ func OpenDatabase(ctx context.Context) (*database.Database, error) {
 	dbPath, err := cfg.GetDatabasePath()
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve database path: %w", err)
+	}
+
+	// Pre-flight: fail fast with a human-readable message if the DB file is absent.
+	if err = CheckDatabaseExists(dbPath); err != nil {
+		return nil, err
 	}
 
 	// Open database with auto-migration enabled

--- a/internal/cli/database_test.go
+++ b/internal/cli/database_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/asphaltbuffet/wherehouse/internal/config"
+	"github.com/asphaltbuffet/wherehouse/internal/database"
 )
 
 func TestOpenDatabase(t *testing.T) {
@@ -23,9 +24,19 @@ func TestOpenDatabase(t *testing.T) {
 			name: "success with valid config",
 			setup: func(t *testing.T) context.Context {
 				t.Helper()
-				// Create temp dir for test database
+				// Create temp dir and pre-initialize the database file so OpenDatabase
+				// can find it (OpenDatabase now requires the file to exist).
 				tmpDir := t.TempDir()
 				dbPath := filepath.Join(tmpDir, "test.db")
+
+				// Pre-create the database file via database.Open so it is a valid SQLite file.
+				initDB, err := database.Open(database.Config{
+					Path:        dbPath,
+					BusyTimeout: database.DefaultBusyTimeout,
+					AutoMigrate: true,
+				})
+				require.NoError(t, err)
+				require.NoError(t, initDB.Close())
 
 				cfg := &config.Config{
 					Database: config.DatabaseConfig{
@@ -56,16 +67,42 @@ func TestOpenDatabase(t *testing.T) {
 			errMsg:  "configuration not found in context",
 		},
 		{
+			name: "error when database file does not exist",
+			setup: func(t *testing.T) context.Context {
+				t.Helper()
+				// Provide a path to a file that was never created.
+				tmpDir := t.TempDir()
+				dbPath := filepath.Join(tmpDir, "nonexistent.db")
+
+				cfg := &config.Config{
+					Database: config.DatabaseConfig{
+						Path: dbPath,
+					},
+				}
+				return context.WithValue(context.Background(), config.ConfigKey, cfg)
+			},
+			wantErr: true,
+			errMsg:  "database not found at",
+		},
+		{
 			name: "success with empty path uses default",
 			setup: func(t *testing.T) context.Context {
 				t.Helper()
-				// Empty path uses system default. We need to ensure the parent directory exists.
-				// Create a temp directory and set WHEREHOUSE_DB_PATH to use it
+				// Empty path uses system default. Pre-create the file via env var override.
 				tmpDir := t.TempDir()
 				dbPath := filepath.Join(tmpDir, "default.db")
 
 				// Set environment variable for this test
 				t.Setenv("WHEREHOUSE_DB_PATH", dbPath)
+
+				// Pre-create the database file.
+				initDB, err := database.Open(database.Config{
+					Path:        dbPath,
+					BusyTimeout: database.DefaultBusyTimeout,
+					AutoMigrate: true,
+				})
+				require.NoError(t, err)
+				require.NoError(t, initDB.Close())
 
 				cfg := &config.Config{
 					Database: config.DatabaseConfig{
@@ -80,11 +117,20 @@ func TestOpenDatabase(t *testing.T) {
 			name: "success with nested directory creation",
 			setup: func(t *testing.T) context.Context {
 				t.Helper()
-				// Create temp dir and ensure parent directory exists
+				// Create temp dir and ensure parent directory exists, then pre-create the DB file.
 				tmpDir := t.TempDir()
 				nestedDir := filepath.Join(tmpDir, "subdir1", "subdir2")
-				require.NoError(t, os.MkdirAll(nestedDir, 0755))
+				require.NoError(t, os.MkdirAll(nestedDir, 0o755))
 				dbPath := filepath.Join(nestedDir, "test.db")
+
+				// Pre-create the database file.
+				initDB, err := database.Open(database.Config{
+					Path:        dbPath,
+					BusyTimeout: database.DefaultBusyTimeout,
+					AutoMigrate: true,
+				})
+				require.NoError(t, err)
+				require.NoError(t, initDB.Close())
 
 				cfg := &config.Config{
 					Database: config.DatabaseConfig{
@@ -99,7 +145,8 @@ func TestOpenDatabase(t *testing.T) {
 			name: "error when path points to directory",
 			setup: func(t *testing.T) context.Context {
 				t.Helper()
-				// Create a directory
+				// Create a directory; os.Stat on a directory succeeds (file exists check
+				// passes), but database.Open will return its own error.
 				tmpDir := t.TempDir()
 
 				cfg := &config.Config{
@@ -123,7 +170,7 @@ func TestOpenDatabase(t *testing.T) {
 				// Create temp dir with restricted permissions
 				tmpDir := t.TempDir()
 				restrictedDir := filepath.Join(tmpDir, "restricted")
-				err := os.Mkdir(restrictedDir, 0444) // Read-only directory
+				err := os.Mkdir(restrictedDir, 0o444) // Read-only directory
 				require.NoError(t, err)
 
 				dbPath := filepath.Join(restrictedDir, "test.db")
@@ -136,7 +183,7 @@ func TestOpenDatabase(t *testing.T) {
 				return context.WithValue(context.Background(), config.ConfigKey, cfg)
 			},
 			wantErr: true,
-			errMsg:  "", // Permission error message varies by OS
+			errMsg:  "", // Permission error or "database not found" depending on os.Stat behavior
 		},
 	}
 
@@ -163,9 +210,19 @@ func TestOpenDatabase(t *testing.T) {
 }
 
 func TestOpenDatabase_AutoMigration(t *testing.T) {
-	// Create temp database
+	// OpenDatabase requires the database file to already exist (use
+	// `wherehouse initialize database` to create it). Pre-create the file here.
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")
+
+	// Pre-initialize the database.
+	initDB, err := database.Open(database.Config{
+		Path:        dbPath,
+		BusyTimeout: database.DefaultBusyTimeout,
+		AutoMigrate: true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, initDB.Close())
 
 	cfg := &config.Config{
 		Database: config.DatabaseConfig{
@@ -174,21 +231,30 @@ func TestOpenDatabase_AutoMigration(t *testing.T) {
 	}
 	ctx := context.WithValue(context.Background(), config.ConfigKey, cfg)
 
-	// Open database (should auto-migrate)
+	// Open database (applies auto-migration on an existing file).
 	db, err := OpenDatabase(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, db)
 	defer db.Close()
 
-	// Verify database was created
+	// Verify database file still exists.
 	_, err = os.Stat(dbPath)
-	assert.NoError(t, err, "database file should exist")
+	assert.NoError(t, err, "database file should still exist after open")
 }
 
 func TestOpenDatabase_ContextPropagation(t *testing.T) {
-	// Verify that context is properly used throughout the call chain
+	// Verify that context is properly used throughout the call chain.
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")
+
+	// Pre-initialize the database so CheckDatabaseExists passes.
+	initDB, err := database.Open(database.Config{
+		Path:        dbPath,
+		BusyTimeout: database.DefaultBusyTimeout,
+		AutoMigrate: true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, initDB.Close())
 
 	cfg := &config.Config{
 		Database: config.DatabaseConfig{
@@ -196,7 +262,7 @@ func TestOpenDatabase_ContextPropagation(t *testing.T) {
 		},
 	}
 
-	// Use a custom context value to verify propagation
+	// Use a custom context value to verify propagation.
 	type testKey string
 	const customKey testKey = "test"
 	ctx := context.WithValue(context.Background(), customKey, "value")
@@ -207,14 +273,23 @@ func TestOpenDatabase_ContextPropagation(t *testing.T) {
 	require.NotNil(t, db)
 	defer db.Close()
 
-	// Verify original context still has custom value
+	// Verify original context still has custom value.
 	assert.Equal(t, "value", ctx.Value(customKey))
 }
 
 func TestOpenDatabase_MultipleCallsSeparate(t *testing.T) {
-	// Test that multiple calls to OpenDatabase create separate connections
+	// Test that multiple calls to OpenDatabase create separate connections.
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")
+
+	// Pre-initialize the database so CheckDatabaseExists passes.
+	initDB, err := database.Open(database.Config{
+		Path:        dbPath,
+		BusyTimeout: database.DefaultBusyTimeout,
+		AutoMigrate: true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, initDB.Close())
 
 	cfg := &config.Config{
 		Database: config.DatabaseConfig{
@@ -223,24 +298,24 @@ func TestOpenDatabase_MultipleCallsSeparate(t *testing.T) {
 	}
 	ctx := context.WithValue(context.Background(), config.ConfigKey, cfg)
 
-	// Open first connection
+	// Open first connection.
 	db1, err := OpenDatabase(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, db1)
 	defer db1.Close()
 
-	// Open second connection
+	// Open second connection.
 	db2, err := OpenDatabase(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, db2)
 	defer db2.Close()
 
-	// Verify both are different instances (pointer comparison)
+	// Verify both are different instances (pointer comparison).
 	assert.NotSame(t, db1, db2)
 }
 
 func TestOpenDatabase_ExistingDatabase(t *testing.T) {
-	// Test opening an existing database file
+	// Test opening an existing database file.
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")
 
@@ -251,20 +326,94 @@ func TestOpenDatabase_ExistingDatabase(t *testing.T) {
 	}
 	ctx := context.WithValue(context.Background(), config.ConfigKey, cfg)
 
-	// Create database first
-	db1, err := OpenDatabase(ctx)
+	// Initialize database directly (bypassing OpenDatabase, which requires the file to exist).
+	db1, err := database.Open(database.Config{
+		Path:        dbPath,
+		BusyTimeout: database.DefaultBusyTimeout,
+		AutoMigrate: true,
+	})
 	require.NoError(t, err)
 	require.NotNil(t, db1)
 	db1.Close()
 
-	// Open existing database
+	// Open existing database via OpenDatabase.
 	db2, err := OpenDatabase(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, db2)
 	defer db2.Close()
 
-	// Verify database file exists
+	// Verify database file exists and is a file (not directory).
 	info, err := os.Stat(dbPath)
 	require.NoError(t, err)
 	assert.False(t, info.IsDir())
+}
+
+func TestCheckDatabaseExists(t *testing.T) {
+	tests := []struct {
+		name         string
+		setup        func(t *testing.T) string
+		wantErr      bool
+		wantSentinel bool
+		errContains  string
+	}{
+		{
+			name: "file present returns nil",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				tmpDir := t.TempDir()
+				dbPath := filepath.Join(tmpDir, "test.db")
+				// Create a non-empty file so os.Stat sees a regular file.
+				f, err := os.Create(dbPath)
+				require.NoError(t, err)
+				require.NoError(t, f.Close())
+				return dbPath
+			},
+			wantErr:      false,
+			wantSentinel: false,
+		},
+		{
+			name: "file absent dir present returns ErrDatabaseNotInitialized",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				// Create the directory but not the file.
+				tmpDir := t.TempDir()
+				return filepath.Join(tmpDir, "missing.db")
+			},
+			wantErr:      true,
+			wantSentinel: true,
+			errContains:  "database not found at",
+		},
+		{
+			name: "dir absent returns ErrDatabaseNotInitialized",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				// Point to a path whose parent directory does not exist.
+				tmpDir := t.TempDir()
+				return filepath.Join(tmpDir, "nonexistent-subdir", "missing.db")
+			},
+			wantErr:      true,
+			wantSentinel: true,
+			errContains:  "database not found at",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dbPath := tt.setup(t)
+
+			err := CheckDatabaseExists(dbPath)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					require.ErrorContains(t, err, tt.errContains)
+				}
+				if tt.wantSentinel {
+					require.ErrorIs(t, err, ErrDatabaseNotInitialized)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,23 +17,25 @@ func TestNew_WithDefaultPaths(t *testing.T) {
 		expectedDBPath string
 		expectedUser   string
 		expectedFormat string
-		expectError    bool
+		errAssertion   require.ErrorAssertionFunc
 	}{
 		{
 			name: "no config files - use defaults",
 			setupFS: func(_ afero.Fs) {
+				t.Helper()
 				// No config files
 			},
 			expectedDBPath: "/home/user/.local/share/wherehouse/wherehouse.db", // XDG-compliant default on Linux
 			expectedUser:   "",
 			expectedFormat: "human",
-			expectError:    false,
+			errAssertion:   require.NoError,
 		},
 		{
 			name: "global config only",
 			setupFS: func(fs afero.Fs) {
+				t.Helper()
 				globalPath := "/home/user/.config/wherehouse/wherehouse.toml"
-				require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0755))
+				require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0o755))
 				content := `[database]
 path = "/global/db.sqlite"
 
@@ -43,35 +45,37 @@ default_identity = "alice"
 [output]
 default_format = "json"
 `
-				require.NoError(t, afero.WriteFile(fs, globalPath, []byte(content), 0644))
+				require.NoError(t, afero.WriteFile(fs, globalPath, []byte(content), 0o644))
 			},
 			expectedDBPath: "/global/db.sqlite",
 			expectedUser:   "alice",
 			expectedFormat: "json",
-			expectError:    false,
+			errAssertion:   require.NoError,
 		},
 		{
 			name: "local config only",
 			setupFS: func(fs afero.Fs) {
+				t.Helper()
 				content := `[database]
 path = "/local/db.sqlite"
 
 [user]
 default_identity = "bob"
 `
-				require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(content), 0644))
+				require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(content), 0o644))
 			},
 			expectedDBPath: "/local/db.sqlite",
 			expectedUser:   "bob",
 			expectedFormat: "human", // default
-			expectError:    false,
+			errAssertion:   require.NoError,
 		},
 		{
 			name: "global and local config - local overrides",
 			setupFS: func(fs afero.Fs) {
+				t.Helper()
 				// Global config
 				globalPath := "/home/user/.config/wherehouse/wherehouse.toml"
-				require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0755))
+				require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0o755))
 				globalContent := `[database]
 path = "/global/db.sqlite"
 
@@ -82,7 +86,7 @@ default_identity = "alice"
 default_format = "json"
 quiet = false
 `
-				require.NoError(t, afero.WriteFile(fs, globalPath, []byte(globalContent), 0644))
+				require.NoError(t, afero.WriteFile(fs, globalPath, []byte(globalContent), 0o644))
 
 				// Local config (overrides some values)
 				localContent := `[database]
@@ -91,18 +95,17 @@ path = "/local/db.sqlite"
 [output]
 quiet = true
 `
-				require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(localContent), 0644))
+				require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(localContent), 0o644))
 			},
 			expectedDBPath: "/local/db.sqlite", // from local
 			expectedUser:   "alice",            // from global
 			expectedFormat: "json",             // from global
-			expectError:    false,
+			errAssertion:   require.NoError,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create in-memory filesystem
 			fs := afero.NewMemMapFs()
 
 			// Set up HOME for global config path resolution
@@ -110,18 +113,12 @@ quiet = true
 			t.Setenv("XDG_CONFIG_HOME", "")
 			t.Setenv("XDG_DATA_HOME", "") // Ensure XDG_DATA_HOME is unset for consistent test behavior
 
-			// Setup filesystem state
 			tt.setupFS(fs)
 
 			// Load config
 			cfg, err := NewWithFS(fs, "")
 
-			if tt.expectError {
-				assert.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
+			tt.errAssertion(t, err)
 			assert.Equal(t, tt.expectedDBPath, cfg.Database.Path)
 			assert.Equal(t, tt.expectedUser, cfg.User.DefaultIdentity)
 			assert.Equal(t, tt.expectedFormat, cfg.Output.DefaultFormat)
@@ -142,11 +139,12 @@ func TestNew_WithExplicitPath(t *testing.T) {
 			name:     "explicit file exists",
 			filepath: "/custom/config.toml",
 			setupFS: func(fs afero.Fs) {
-				require.NoError(t, fs.MkdirAll("/custom", 0755))
+				t.Helper()
+				require.NoError(t, fs.MkdirAll("/custom", 0o755))
 				content := `[database]
 path = "/custom/db.sqlite"
 `
-				require.NoError(t, afero.WriteFile(fs, "/custom/config.toml", []byte(content), 0644))
+				require.NoError(t, afero.WriteFile(fs, "/custom/config.toml", []byte(content), 0o644))
 			},
 			expectError: false,
 		},
@@ -154,6 +152,7 @@ path = "/custom/db.sqlite"
 			name:     "explicit file not found",
 			filepath: "/missing/config.toml",
 			setupFS: func(_ afero.Fs) {
+				t.Helper()
 				// File doesn't exist
 			},
 			expectError: true,
@@ -163,10 +162,11 @@ path = "/custom/db.sqlite"
 			name:     "explicit file with invalid TOML",
 			filepath: "/bad/config.toml",
 			setupFS: func(fs afero.Fs) {
-				require.NoError(t, fs.MkdirAll("/bad", 0755))
+				t.Helper()
+				require.NoError(t, fs.MkdirAll("/bad", 0o755))
 				content := `[database
 path = broken`
-				require.NoError(t, afero.WriteFile(fs, "/bad/config.toml", []byte(content), 0644))
+				require.NoError(t, afero.WriteFile(fs, "/bad/config.toml", []byte(content), 0o644))
 			},
 			expectError: true,
 			errorMsg:    "failed to read config file",
@@ -180,16 +180,12 @@ path = broken`
 
 			cfg, err := NewWithFS(fs, tt.filepath)
 
-			if tt.expectError {
-				assert.Error(t, err)
-				if tt.errorMsg != "" {
-					assert.Contains(t, err.Error(), tt.errorMsg)
-				}
-				return
+			if tt.errorMsg != "" {
+				require.ErrorContains(t, err, tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, cfg)
 			}
-
-			require.NoError(t, err)
-			assert.NotNil(t, cfg)
 		})
 	}
 }
@@ -197,10 +193,9 @@ path = broken`
 // TestValidation tests configuration validation.
 func TestValidation(t *testing.T) {
 	tests := []struct {
-		name        string
-		config      *Config
-		expectError bool
-		errorMsg    string
+		name     string
+		config   *Config
+		errorMsg string
 	}{
 		{
 			name: "valid config",
@@ -209,7 +204,6 @@ func TestValidation(t *testing.T) {
 				User:     UserConfig{DefaultIdentity: "alice"},
 				Output:   OutputConfig{DefaultFormat: "human"},
 			},
-			expectError: false,
 		},
 		{
 			name: "empty database path",
@@ -217,8 +211,7 @@ func TestValidation(t *testing.T) {
 				Database: DatabaseConfig{Path: ""},
 				Output:   OutputConfig{DefaultFormat: "human"},
 			},
-			expectError: true,
-			errorMsg:    "path is required",
+			errorMsg: "path is required",
 		},
 		{
 			name: "invalid output format",
@@ -226,8 +219,7 @@ func TestValidation(t *testing.T) {
 				Database: DatabaseConfig{Path: "/path/to/db.sqlite"},
 				Output:   OutputConfig{DefaultFormat: "xml"},
 			},
-			expectError: true,
-			errorMsg:    "must be one of [human, json]",
+			errorMsg: "must be one of [human, json]",
 		},
 	}
 
@@ -235,12 +227,11 @@ func TestValidation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validate(tt.config)
 
-			if tt.expectError {
-				assert.ErrorContains(t, err, tt.errorMsg)
-				return
+			if tt.errorMsg != "" {
+				require.ErrorContains(t, err, tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
 			}
-
-			assert.NoError(t, err)
 		})
 	}
 }
@@ -263,64 +254,71 @@ func TestExpandPath(t *testing.T) {
 	t.Setenv("TESTVAR", "myvalue")
 
 	tests := []struct {
-		name        string
-		input       string
-		expectError bool
-		checkResult func(t *testing.T, result string)
+		name         string
+		input        string
+		errAssertion require.ErrorAssertionFunc
+		checkResult  func(t *testing.T, result string)
 	}{
 		{
-			name:        "empty path",
-			input:       "",
-			expectError: false,
+			name:         "empty path",
+			input:        "",
+			errAssertion: require.NoError,
 			checkResult: func(t *testing.T, result string) {
+				t.Helper()
 				assert.Empty(t, result)
 			},
 		},
 		{
-			name:        "absolute path unchanged",
-			input:       "/absolute/path/to/db.sqlite",
-			expectError: false,
+			name:         "absolute path unchanged",
+			input:        "/absolute/path/to/db.sqlite",
+			errAssertion: require.NoError,
 			checkResult: func(t *testing.T, result string) {
+				t.Helper()
 				assert.Equal(t, "/absolute/path/to/db.sqlite", result)
 			},
 		},
 		{
-			name:        "tilde expansion",
-			input:       "~/mydb.sqlite",
-			expectError: false,
+			name:         "tilde expansion",
+			input:        "~/mydb.sqlite",
+			errAssertion: require.NoError,
 			checkResult: func(t *testing.T, result string) {
+				t.Helper()
 				assert.Equal(t, "/home/testuser/mydb.sqlite", result)
 			},
 		},
 		{
-			name:        "tilde only",
-			input:       "~",
-			expectError: false,
+			name:         "tilde only",
+			input:        "~",
+			errAssertion: require.NoError,
 			checkResult: func(t *testing.T, result string) {
+				t.Helper()
 				assert.Equal(t, "/home/testuser", result)
 			},
 		},
 		{
-			name:        "tilde username rejected",
-			input:       "~bob/mydb.sqlite",
-			expectError: true,
+			name:         "tilde username rejected",
+			input:        "~bob/mydb.sqlite",
+			errAssertion: require.Error,
 			checkResult: func(_ *testing.T, _ string) {
+				t.Helper()
 				// Error should be returned
 			},
 		},
 		{
-			name:        "environment variable expansion",
-			input:       "/path/$TESTVAR/db.sqlite",
-			expectError: false,
+			name:         "environment variable expansion",
+			input:        "/path/$TESTVAR/db.sqlite",
+			errAssertion: require.NoError,
 			checkResult: func(t *testing.T, result string) {
+				t.Helper()
 				assert.Equal(t, "/path/myvalue/db.sqlite", result)
 			},
 		},
 		{
-			name:        "relative path made absolute",
-			input:       "relative/path/db.sqlite",
-			expectError: false,
+			name:         "relative path made absolute",
+			input:        "relative/path/db.sqlite",
+			errAssertion: require.NoError,
 			checkResult: func(t *testing.T, result string) {
+				t.Helper()
 				assert.True(t, filepath.IsAbs(result))
 				assert.Contains(t, result, "relative/path/db.sqlite")
 			},
@@ -331,12 +329,7 @@ func TestExpandPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := ExpandPath(tt.input)
 
-			if tt.expectError {
-				assert.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
+			tt.errAssertion(t, err)
 			tt.checkResult(t, result)
 		})
 	}
@@ -352,6 +345,7 @@ func TestGetCurrentUsername(t *testing.T) {
 		{
 			name: "USER environment variable set",
 			setupEnv: func(t *testing.T) {
+				t.Helper()
 				t.Setenv("USER", "alice")
 				t.Setenv("USERNAME", "")
 			},
@@ -360,6 +354,7 @@ func TestGetCurrentUsername(t *testing.T) {
 		{
 			name: "USERNAME environment variable set",
 			setupEnv: func(t *testing.T) {
+				t.Helper()
 				t.Setenv("USER", "")
 				t.Setenv("USERNAME", "bob")
 			},
@@ -368,6 +363,7 @@ func TestGetCurrentUsername(t *testing.T) {
 		{
 			name: "no environment variables set",
 			setupEnv: func(t *testing.T) {
+				t.Helper()
 				t.Setenv("USER", "")
 				t.Setenv("USERNAME", "")
 			},
@@ -394,14 +390,14 @@ func TestEnvironmentVariableOverride(t *testing.T) {
 
 	// Create global config
 	globalPath := "/home/user/.config/wherehouse/wherehouse.toml"
-	require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0755))
+	require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0o755))
 	content := `[database]
 path = "/from/config.sqlite"
 
 [user]
 default_identity = "alice"
 `
-	require.NoError(t, afero.WriteFile(fs, globalPath, []byte(content), 0644))
+	require.NoError(t, afero.WriteFile(fs, globalPath, []byte(content), 0o644))
 
 	// Set environment variables to override config
 	t.Setenv("WHEREHOUSE_DATABASE_PATH", "/from/env.sqlite")
@@ -426,7 +422,7 @@ default_identity = ""
 "jdoe" = "john.doe"
 "asmith" = "alice.smith"
 `
-	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(content), 0644))
+	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(content), 0o644))
 
 	t.Setenv("HOME", "/home/user")
 
@@ -445,7 +441,7 @@ func TestQuietFlag(t *testing.T) {
 	content := `[output]
 quiet = 1
 `
-	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(content), 0644))
+	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(content), 0o644))
 
 	t.Setenv("HOME", "/home/user")
 
@@ -462,7 +458,7 @@ func TestGetDefaults(t *testing.T) {
 	assert.NotNil(t, cfg)
 	assert.NotEmpty(t, cfg.Database.Path)
 	assert.Equal(t, "human", cfg.Output.DefaultFormat)
-	assert.Equal(t, 0, cfg.Output.Quiet)
+	assert.Zero(t, cfg.Output.Quiet)
 	assert.NotNil(t, cfg.User.OSUsernameMap)
 }
 
@@ -476,27 +472,27 @@ func TestWHEREHOUSE_CONFIG(t *testing.T) {
 
 	// Create a custom config file
 	customPath := "/custom/my-config.toml"
-	require.NoError(t, fs.MkdirAll(filepath.Dir(customPath), 0755))
+	require.NoError(t, fs.MkdirAll(filepath.Dir(customPath), 0o755))
 	content := `[database]
 path = "/custom/db.sqlite"
 
 [user]
 default_identity = "custom-user"
 `
-	require.NoError(t, afero.WriteFile(fs, customPath, []byte(content), 0644))
+	require.NoError(t, afero.WriteFile(fs, customPath, []byte(content), 0o644))
 
 	// Also create global and local configs (should be ignored)
 	globalPath := "/home/user/.config/wherehouse/wherehouse.toml"
-	require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0755))
+	require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0o755))
 	globalContent := `[database]
 path = "/global/db.sqlite"
 `
-	require.NoError(t, afero.WriteFile(fs, globalPath, []byte(globalContent), 0644))
+	require.NoError(t, afero.WriteFile(fs, globalPath, []byte(globalContent), 0o644))
 
 	localContent := `[database]
 path = "/local/db.sqlite"
 `
-	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(localContent), 0644))
+	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(localContent), 0o644))
 
 	// Set WHEREHOUSE_CONFIG environment variable
 	t.Setenv("WHEREHOUSE_CONFIG", customPath)
@@ -520,7 +516,7 @@ func TestConfigPrecedence(t *testing.T) {
 
 	// Create global config
 	globalPath := "/home/user/.config/wherehouse/wherehouse.toml"
-	require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0755))
+	require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0o755))
 	globalContent := `[database]
 path = "/global/db.sqlite"
 
@@ -531,7 +527,7 @@ default_identity = "global-user"
 default_format = "json"
 quiet = 0
 `
-	require.NoError(t, afero.WriteFile(fs, globalPath, []byte(globalContent), 0644))
+	require.NoError(t, afero.WriteFile(fs, globalPath, []byte(globalContent), 0o644))
 
 	// Create local config (overrides some global values)
 	localContent := `[database]
@@ -540,7 +536,7 @@ path = "/local/db.sqlite"
 [output]
 quiet = 1
 `
-	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(localContent), 0644))
+	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(localContent), 0o644))
 
 	// Set environment variables (override both config files)
 	t.Setenv("WHEREHOUSE_OUTPUT_DEFAULT_FORMAT", "human")
@@ -569,11 +565,11 @@ func TestXDG_CONFIG_HOME(t *testing.T) {
 
 	// Create config at XDG location
 	xdgPath := "/custom/config/wherehouse/wherehouse.toml"
-	require.NoError(t, fs.MkdirAll(filepath.Dir(xdgPath), 0755))
+	require.NoError(t, fs.MkdirAll(filepath.Dir(xdgPath), 0o755))
 	content := `[database]
 path = "/xdg/db.sqlite"
 `
-	require.NoError(t, afero.WriteFile(fs, xdgPath, []byte(content), 0644))
+	require.NoError(t, afero.WriteFile(fs, xdgPath, []byte(content), 0o644))
 
 	cfg, err := NewWithFS(fs, "")
 	require.NoError(t, err)
@@ -591,21 +587,21 @@ func TestExplicitFileOverridesDefaults(t *testing.T) {
 
 	// Create global and local configs
 	globalPath := "/home/user/.config/wherehouse/wherehouse.toml"
-	require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0755))
+	require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0o755))
 	require.NoError(t, afero.WriteFile(fs, globalPath, []byte(`[database]
 path = "/global/db.sqlite"
-`), 0644))
+`), 0o644))
 
 	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(`[database]
 path = "/local/db.sqlite"
-`), 0644))
+`), 0o644))
 
 	// Create explicit config file
 	customPath := "/custom/override.toml"
-	require.NoError(t, fs.MkdirAll(filepath.Dir(customPath), 0755))
+	require.NoError(t, fs.MkdirAll(filepath.Dir(customPath), 0o755))
 	require.NoError(t, afero.WriteFile(fs, customPath, []byte(`[database]
 path = "/explicit/db.sqlite"
-`), 0644))
+`), 0o644))
 
 	// Load with explicit path
 	cfg, err := NewWithFS(fs, customPath)
@@ -626,7 +622,7 @@ func TestPathExpansionInConfig(t *testing.T) {
 	content := `[database]
 path = "~/mydb.sqlite"
 `
-	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(content), 0644))
+	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(content), 0o644))
 
 	cfg, err := NewWithFS(fs, "")
 	require.NoError(t, err)
@@ -650,7 +646,7 @@ func TestEmptyLocalConfigWithGlobalValues(t *testing.T) {
 
 	// Create global config
 	globalPath := "/home/user/.config/wherehouse/wherehouse.toml"
-	require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0755))
+	require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0o755))
 	globalContent := `[database]
 path = "/global/db.sqlite"
 
@@ -661,10 +657,10 @@ default_identity = "alice"
 default_format = "json"
 quiet = false
 `
-	require.NoError(t, afero.WriteFile(fs, globalPath, []byte(globalContent), 0644))
+	require.NoError(t, afero.WriteFile(fs, globalPath, []byte(globalContent), 0o644))
 
 	// Create empty local config
-	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(""), 0644))
+	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(""), 0o644))
 
 	cfg, err := NewWithFS(fs, "")
 	require.NoError(t, err)
@@ -673,7 +669,7 @@ quiet = false
 	assert.Equal(t, "/global/db.sqlite", cfg.Database.Path)
 	assert.Equal(t, "alice", cfg.User.DefaultIdentity)
 	assert.Equal(t, "json", cfg.Output.DefaultFormat)
-	assert.Equal(t, 0, cfg.Output.Quiet)
+	assert.Zero(t, cfg.Output.Quiet)
 }
 
 // TestValidateExportedFunction tests the exported Validate function.
@@ -689,9 +685,7 @@ func TestValidateExportedFunction(t *testing.T) {
 
 	// Test validation error
 	cfg.Output.DefaultFormat = "invalid"
-	err = Validate(cfg)
-	require.Error(t, err, "validation should fail for invalid format")
-	assert.Contains(t, err.Error(), "must be one of [human, json]")
+	require.ErrorContains(t, Validate(cfg), "must be one of [human, json]")
 }
 
 // TestEnvironmentVariableOverrideAllLevels tests env vars override all config sources.
@@ -704,7 +698,7 @@ func TestEnvironmentVariableOverrideAllLevels(t *testing.T) {
 
 	// Create global config
 	globalPath := "/home/user/.config/wherehouse/wherehouse.toml"
-	require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0755))
+	require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0o755))
 	globalContent := `[database]
 path = "/global/db.sqlite"
 
@@ -715,7 +709,7 @@ default_identity = "alice"
 default_format = "json"
 quiet = 0
 `
-	require.NoError(t, afero.WriteFile(fs, globalPath, []byte(globalContent), 0644))
+	require.NoError(t, afero.WriteFile(fs, globalPath, []byte(globalContent), 0o644))
 
 	// Create local config with different values
 	localContent := `[database]
@@ -728,7 +722,7 @@ default_identity = "bob"
 default_format = "human"
 quiet = 0
 `
-	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(localContent), 0644))
+	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(localContent), 0o644))
 
 	// Set environment variables for all values
 	t.Setenv("WHEREHOUSE_DATABASE_PATH", "/env/db.sqlite")
@@ -756,7 +750,7 @@ func TestPartialLocalConfigOverride(t *testing.T) {
 
 	// Create global config with multiple values
 	globalPath := "/home/user/.config/wherehouse/wherehouse.toml"
-	require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0755))
+	require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0o755))
 	globalContent := `[database]
 path = "/global/db.sqlite"
 
@@ -767,13 +761,13 @@ default_identity = "alice"
 default_format = "json"
 quiet = 0
 `
-	require.NoError(t, afero.WriteFile(fs, globalPath, []byte(globalContent), 0644))
+	require.NoError(t, afero.WriteFile(fs, globalPath, []byte(globalContent), 0o644))
 
 	// Create local config that overrides ONLY database path
 	localContent := `[database]
 path = "/local/db.sqlite"
 `
-	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(localContent), 0644))
+	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(localContent), 0o644))
 
 	cfg, err := NewWithFS(fs, "")
 	require.NoError(t, err)
@@ -795,7 +789,7 @@ func TestComplexMergeScenario(t *testing.T) {
 
 	// Create global config
 	globalPath := "/home/user/.config/wherehouse/wherehouse.toml"
-	require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0755))
+	require.NoError(t, fs.MkdirAll(filepath.Dir(globalPath), 0o755))
 	globalContent := `[database]
 path = "/global/db.sqlite"
 
@@ -806,7 +800,7 @@ default_identity = "alice"
 default_format = "json"
 quiet = 0
 `
-	require.NoError(t, afero.WriteFile(fs, globalPath, []byte(globalContent), 0644))
+	require.NoError(t, afero.WriteFile(fs, globalPath, []byte(globalContent), 0o644))
 
 	// Create local config (overrides database and quiet)
 	localContent := `[database]
@@ -815,7 +809,7 @@ path = "/local/db.sqlite"
 [output]
 quiet = 1
 `
-	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(localContent), 0644))
+	require.NoError(t, afero.WriteFile(fs, "./wherehouse.toml", []byte(localContent), 0o644))
 
 	// Set environment variables (override output format)
 	t.Setenv("WHEREHOUSE_OUTPUT_DEFAULT_FORMAT", "human")

--- a/internal/config/database_test.go
+++ b/internal/config/database_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -22,6 +21,7 @@ func TestDefaultDatabasePath(t *testing.T) {
 			name:     "linux with XDG_DATA_HOME",
 			platform: goosLinux,
 			envSetup: func(t *testing.T) {
+				t.Helper()
 				t.Setenv("XDG_DATA_HOME", "/home/testuser/.local/share")
 				t.Setenv("HOME", "/home/testuser")
 			},
@@ -32,6 +32,7 @@ func TestDefaultDatabasePath(t *testing.T) {
 			name:     "linux without XDG_DATA_HOME",
 			platform: goosLinux,
 			envSetup: func(t *testing.T) {
+				t.Helper()
 				t.Setenv("XDG_DATA_HOME", "")
 				t.Setenv("HOME", "/home/testuser")
 			},
@@ -42,6 +43,7 @@ func TestDefaultDatabasePath(t *testing.T) {
 			name:     "linux without HOME falls back gracefully",
 			platform: goosLinux,
 			envSetup: func(t *testing.T) {
+				t.Helper()
 				t.Setenv("XDG_DATA_HOME", "")
 				t.Setenv("HOME", "")
 			},
@@ -51,6 +53,7 @@ func TestDefaultDatabasePath(t *testing.T) {
 			name:     "darwin with HOME",
 			platform: goosDarwin,
 			envSetup: func(t *testing.T) {
+				t.Helper()
 				t.Setenv("HOME", "/Users/testuser")
 			},
 			wantContains: "/Users/testuser/Library/Application Support/wherehouse",
@@ -60,6 +63,7 @@ func TestDefaultDatabasePath(t *testing.T) {
 			name:     "darwin without HOME falls back gracefully",
 			platform: goosDarwin,
 			envSetup: func(t *testing.T) {
+				t.Helper()
 				t.Setenv("HOME", "")
 			},
 			wantSuffix: "wherehouse.db",
@@ -73,67 +77,16 @@ func TestDefaultDatabasePath(t *testing.T) {
 				t.Skipf("skipping %s test on %s platform", tt.platform, runtime.GOOS)
 			}
 
-			// Setup environment for this test
 			tt.envSetup(t)
-
-			// Get path
 			path := DefaultDatabasePath()
 
-			// Verify path is not empty
-			assert.NotEmpty(t, path, "path should not be empty")
+			assert.NotEmpty(t, path)
+			assert.Equal(t, "wherehouse.db", filepath.Base(path))
 
-			// Verify suffix
-			assert.Equal(t, "wherehouse.db", filepath.Base(path),
-				"path should end with wherehouse.db, got: %s", path)
-
-			// Verify contains expected substring (if specified)
 			if tt.wantContains != "" {
-				assert.Contains(t, path, tt.wantContains,
-					"path should contain %q, got: %s", tt.wantContains, path)
-			}
-
-			// Verify path is absolute or relative (for fallback cases)
-			if tt.wantContains != "" {
-				assert.True(t, filepath.IsAbs(path) || path == "./wherehouse.db",
-					"path should be absolute or fallback, got: %s", path)
+				assert.Contains(t, path, tt.wantContains)
 			}
 		})
-	}
-}
-
-func TestDefaultDatabasePath_CurrentPlatform(t *testing.T) {
-	// Test current platform without mocking environment
-	path := DefaultDatabasePath()
-
-	// Verify path is not empty
-	require.NotEmpty(t, path, "path should not be empty")
-
-	// Verify filename
-	assert.Equal(t, "wherehouse.db", filepath.Base(path),
-		"database filename should be wherehouse.db")
-
-	// Verify path contains wherehouse directory
-	assert.Contains(t, path, "wherehouse",
-		"path should contain wherehouse directory")
-
-	// Platform-specific checks
-	switch runtime.GOOS {
-	case goosLinux, goosFreeBSD, goosOpenBSD, goosNetBSD:
-		// Should use XDG or .local/share
-		if xdgDataHome := os.Getenv("XDG_DATA_HOME"); xdgDataHome != "" {
-			assert.Contains(t, path, xdgDataHome)
-		} else {
-			assert.Contains(t, path, ".local/share")
-		}
-
-	case goosDarwin:
-		assert.Contains(t, path, "Library/Application Support")
-
-	case goosWindows:
-		// Should contain APPDATA or fallback
-		assert.True(t,
-			os.Getenv("APPDATA") != "" || os.Getenv("USERPROFILE") != "",
-			"Windows should have APPDATA or USERPROFILE set")
 	}
 }
 
@@ -143,7 +96,6 @@ func TestConfig_GetDatabasePath(t *testing.T) {
 		configPath      string
 		envPath         string
 		wantContains    string
-		wantErr         bool
 		wantErrContains string
 	}{
 		{
@@ -151,48 +103,41 @@ func TestConfig_GetDatabasePath(t *testing.T) {
 			configPath:   "/explicit/path/to/db.db",
 			envPath:      "/env/path/to/db.db",
 			wantContains: "/explicit/path/to/db.db",
-			wantErr:      false,
 		},
 		{
 			name:         "env var used when config empty",
 			configPath:   "",
 			envPath:      "/env/path/to/db.db",
 			wantContains: "/env/path/to/db.db",
-			wantErr:      false,
 		},
 		{
 			name:         "default used when both empty",
 			configPath:   "",
 			envPath:      "",
 			wantContains: "wherehouse.db",
-			wantErr:      false,
 		},
 		{
 			name:         "tilde expansion in config path",
 			configPath:   "~/custom/wherehouse.db",
 			envPath:      "",
 			wantContains: "custom/wherehouse.db",
-			wantErr:      false,
 		},
 		{
 			name:         "tilde expansion in env path",
 			configPath:   "",
 			envPath:      "~/env/wherehouse.db",
 			wantContains: "env/wherehouse.db",
-			wantErr:      false,
 		},
 		{
 			name:            "invalid ~username pattern in config",
 			configPath:      "~someuser/wherehouse.db",
 			envPath:         "",
-			wantErr:         true,
 			wantErrContains: "~username expansion not supported",
 		},
 		{
 			name:            "invalid ~username pattern in env",
 			configPath:      "",
 			envPath:         "~someuser/wherehouse.db",
-			wantErr:         true,
 			wantErrContains: "~username expansion not supported",
 		},
 		{
@@ -200,35 +145,30 @@ func TestConfig_GetDatabasePath(t *testing.T) {
 			configPath:   "$HOME/custom/wherehouse.db",
 			envPath:      "",
 			wantContains: "custom/wherehouse.db",
-			wantErr:      false,
 		},
 		{
 			name:         "relative path in config",
 			configPath:   "./local/wherehouse.db",
 			envPath:      "",
 			wantContains: "wherehouse.db",
-			wantErr:      false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Setup environment
 			if tt.envPath != "" {
 				t.Setenv("WHEREHOUSE_DB_PATH", tt.envPath)
 			}
 
-			// Create config
 			cfg := &Config{
 				Database: DatabaseConfig{
 					Path: tt.configPath,
 				},
 			}
 
-			// Call GetDatabasePath
 			dbPath, pathErr := cfg.GetDatabasePath()
 
-			if tt.wantErr {
+			if tt.wantErrContains != "" {
 				require.ErrorContains(t, pathErr, tt.wantErrContains)
 			} else {
 				require.NoError(t, pathErr)
@@ -240,7 +180,6 @@ func TestConfig_GetDatabasePath(t *testing.T) {
 }
 
 func TestConfig_GetDatabasePath_Precedence(t *testing.T) {
-	// Test 1: Config path overrides env
 	t.Run("config overrides env", func(t *testing.T) {
 		t.Setenv("WHEREHOUSE_DB_PATH", "/env/path/db.db")
 
@@ -254,7 +193,6 @@ func TestConfig_GetDatabasePath_Precedence(t *testing.T) {
 		assert.Contains(t, path, "/config/path/db.db")
 	})
 
-	// Test 2: Env used when config empty
 	t.Run("env used when config empty", func(t *testing.T) {
 		t.Setenv("WHEREHOUSE_DB_PATH", "/env/path/db.db")
 
@@ -277,14 +215,15 @@ func TestConfig_GetDatabasePath_Precedence(t *testing.T) {
 		}
 		path, err := cfg.GetDatabasePath()
 		require.NoError(t, err)
-		assert.Contains(t, path, "wherehouse.db")
-		assert.Contains(t, path, "wherehouse") // Should contain directory
+		assert.Contains(t, path, filepath.Join("wherehouse", "wherehouse.db"))
 	})
 }
 
 func TestConfig_GetDatabasePath_ExpandPath(t *testing.T) {
-	home, err := os.UserHomeDir()
-	require.NoError(t, err)
+	home := "/home/fake-user"
+	t.Setenv("HOME", home)
+	pwd := t.TempDir()
+	t.Chdir(pwd)
 
 	tests := []struct {
 		name         string
@@ -314,7 +253,7 @@ func TestConfig_GetDatabasePath_ExpandPath(t *testing.T) {
 		{
 			name:         "relative path made absolute",
 			inputPath:    "relative/wherehouse.db",
-			wantContains: "wherehouse.db",
+			wantContains: filepath.Join(pwd, "relative", "wherehouse.db"),
 		},
 	}
 
@@ -329,7 +268,6 @@ func TestConfig_GetDatabasePath_ExpandPath(t *testing.T) {
 			path, pathErr := cfg.GetDatabasePath()
 			require.NoError(t, pathErr)
 			assert.Contains(t, path, tt.wantContains)
-			assert.True(t, filepath.IsAbs(path))
 		})
 	}
 }

--- a/internal/config/helper_test.go
+++ b/internal/config/helper_test.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+// NewTestFs is a helper function to create a MemMapFS and temporary directory.
+func NewTestFs(t *testing.T) (afero.Fs, string) {
+	t.Helper()
+
+	testFs := afero.NewMemMapFs()
+	testDir, err := afero.TempDir(testFs, "", "")
+	require.NoError(t, err)
+
+	return testFs, testDir
+}
+
+func NewTestFsWithDefaultFile(t *testing.T) (afero.Fs, string) {
+	t.Helper()
+
+	testFs := afero.NewMemMapFs()
+
+	testDir, err := afero.TempDir(testFs, "", "")
+	require.NoError(t, err)
+	defaultConfigFile := filepath.Join(testDir, "test-config.toml")
+
+	require.NoError(t, WriteDefault(testFs, defaultConfigFile, false))
+
+	return testFs, defaultConfigFile
+}

--- a/internal/config/writer.go
+++ b/internal/config/writer.go
@@ -15,9 +15,11 @@ import (
 // Sets the afero filesystem and config file path. Does not read the file.
 func newViperForFile(fs afero.Fs, path string) *viper.Viper {
 	v := viper.New()
+
 	v.SetFs(fs)
 	v.SetConfigFile(path)
 	v.SetConfigType("toml")
+
 	return v
 }
 
@@ -75,6 +77,7 @@ func Set(fs afero.Fs, path string, key string, value string) error {
 	}
 
 	v := newViperForFile(fs, path)
+
 	err := v.ReadInConfig()
 	if err != nil {
 		return fmt.Errorf("reading config file: %w", err)
@@ -84,11 +87,16 @@ func Set(fs afero.Fs, path string, key string, value string) error {
 
 	// Validate the full merged config before writing
 	var cfg Config
-	if err := v.Unmarshal(&cfg); err != nil {
+
+	err = v.Unmarshal(&cfg)
+	if err != nil {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
+
 	applyDefaults(&cfg)
-	if validateErr := validate(&cfg); validateErr != nil {
+
+	validateErr := validate(&cfg)
+	if validateErr != nil {
 		return fmt.Errorf("configuration validation failed: %w", validateErr)
 	}
 
@@ -105,64 +113,46 @@ func Check(fs afero.Fs, path string) error {
 	}
 
 	var cfg Config
-	if err := toml.Unmarshal(data, &cfg); err != nil {
+
+	err = toml.Unmarshal(data, &cfg)
+	if err != nil {
 		return fmt.Errorf("parsing config file: %w", err)
 	}
 
 	applyDefaults(&cfg)
 
-	if validateErr := validate(&cfg); validateErr != nil {
-		return fmt.Errorf("validating config: %w", validateErr)
+	err = validate(&cfg)
+	if err != nil {
+		return fmt.Errorf("validating config: %w", err)
 	}
 
 	return nil
 }
 
 // GetValue returns the value of a dot-separated config key from cfg.
-// Supports all config keys including logging.* and user.os_username_map.
-// Returns (value, nil) on success or (nil, error) for unknown keys.
 func GetValue(cfg *Config, key string) (any, error) {
-	const keyParts = 2
-	parts := strings.SplitN(key, ".", keyParts)
-	if len(parts) != keyParts {
-		return nil, fmt.Errorf("invalid key format %q (expected section.key)", key)
+	switch key {
+	case "database.path":
+		return cfg.Database.Path, nil
+	case "logging.file_path":
+		return cfg.Logging.FilePath, nil
+	case "logging.level":
+		return cfg.Logging.Level, nil
+	case "logging.max_size_mb":
+		return cfg.Logging.MaxSizeMB, nil
+	case "logging.max_backups":
+		return cfg.Logging.MaxBackups, nil
+	case "user.default_identity":
+		return cfg.User.DefaultIdentity, nil
+	case "user.os_username_map":
+		return cfg.User.OSUsernameMap, nil
+	case "output.default_format":
+		return cfg.Output.DefaultFormat, nil
+	case "output.quiet":
+		return cfg.Output.Quiet, nil
+	default:
+		return nil, fmt.Errorf("unknown configuration key %q", key)
 	}
-
-	section, field := parts[0], parts[1]
-
-	switch section {
-	case "database":
-		if field == "path" {
-			return cfg.Database.Path, nil
-		}
-	case "logging":
-		switch field {
-		case "file_path":
-			return cfg.Logging.FilePath, nil
-		case "level":
-			return cfg.Logging.Level, nil
-		case "max_size_mb":
-			return cfg.Logging.MaxSizeMB, nil
-		case "max_backups":
-			return cfg.Logging.MaxBackups, nil
-		}
-	case "user":
-		switch field {
-		case "default_identity":
-			return cfg.User.DefaultIdentity, nil
-		case "os_username_map":
-			return cfg.User.OSUsernameMap, nil
-		}
-	case "output":
-		switch field {
-		case "default_format":
-			return cfg.Output.DefaultFormat, nil
-		case "quiet":
-			return cfg.Output.Quiet, nil
-		}
-	}
-
-	return nil, fmt.Errorf("unknown configuration key %q", key)
 }
 
 // parseConfigValue validates and parses a string value for the given config key.

--- a/internal/config/writer_test.go
+++ b/internal/config/writer_test.go
@@ -14,17 +14,12 @@ import (
 // TestWriteDefault_AllDefaultsRoundTrip verifies round-trip: write via WriteDefault,
 // read back via viper, verify all keys match GetDefaults() values.
 func TestWriteDefault_AllDefaultsRoundTrip(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	path := "/tmp/test-config.toml"
-
-	// Write defaults
-	err := WriteDefault(fs, path, false)
-	require.NoError(t, err)
+	testFs, defaultCfgFile := NewTestFsWithDefaultFile(t)
 
 	// Read back through viper to verify all keys/values
 	v := viper.New()
-	v.SetFs(fs)
-	v.SetConfigFile(path)
+	v.SetFs(testFs)
+	v.SetConfigFile(defaultCfgFile)
 	v.SetConfigType("toml")
 	require.NoError(t, v.ReadInConfig())
 
@@ -41,99 +36,48 @@ func TestWriteDefault_AllDefaultsRoundTrip(t *testing.T) {
 	assert.Equal(t, defaults.Output.Quiet, v.GetInt("output.quiet"))
 }
 
-// TestWriteDefault_CreatesFile verifies file is created in memfs.
+// TestWriteDefault_CreatesFile verifies file is created.
 func TestWriteDefault_CreatesFile(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	path := "/tmp/test-config.toml"
+	testFs, defaultCfgFile := NewTestFsWithDefaultFile(t)
 
-	err := WriteDefault(fs, path, false)
-	require.NoError(t, err)
+	t.Run("file is created", func(t *testing.T) {
+		// Verify file exists
+		exists, err := afero.Exists(testFs, defaultCfgFile)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
 
-	// Verify file exists
-	exists, err := afero.Exists(fs, path)
-	require.NoError(t, err)
-	assert.True(t, exists)
-}
+	t.Run("no overwrite without force", func(t *testing.T) {
+		// Try to write again with force=false
+		err := WriteDefault(testFs, defaultCfgFile, false)
+		assert.ErrorContains(t, err, "already exists")
+	})
 
-// TestWriteDefault_FailsIfExists verifies error when force=false and file exists.
-func TestWriteDefault_FailsIfExists(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	path := "/tmp/test-config.toml"
+	t.Run("force overwrite", func(t *testing.T) {
+		// Overwrite with force=true
+		require.NoError(t, WriteDefault(testFs, defaultCfgFile, true))
 
-	// Create initial file
-	require.NoError(t, WriteDefault(fs, path, false))
-
-	// Try to write again with force=false
-	err := WriteDefault(fs, path, false)
-	assert.ErrorContains(t, err, "already exists")
-}
-
-// TestWriteDefault_ForceOverwrites verifies force=true overwrites existing file.
-func TestWriteDefault_ForceOverwrites(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	path := "/tmp/test-config.toml"
-
-	// Create initial file
-	require.NoError(t, WriteDefault(fs, path, false))
-
-	// Verify first write succeeded
-	exists, err := afero.Exists(fs, path)
-	require.NoError(t, err)
-	assert.True(t, exists)
-
-	// Overwrite with force=true
-	require.NoError(t, WriteDefault(fs, path, true))
-
-	// Verify file still exists and is readable
-	exists, err = afero.Exists(fs, path)
-	require.NoError(t, err)
-	assert.True(t, exists)
-
-	// Verify content is valid
-	v := viper.New()
-	v.SetFs(fs)
-	v.SetConfigFile(path)
-	v.SetConfigType("toml")
-	require.NoError(t, v.ReadInConfig())
-}
-
-// TestWriteDefault_CreatesParentDirs verifies parent directories are created.
-func TestWriteDefault_CreatesParentDirs(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	path := "/deep/nested/dir/config.toml"
-
-	require.NoError(t, WriteDefault(fs, path, false))
-
-	// Verify file exists
-	exists, err := afero.Exists(fs, path)
-	require.NoError(t, err)
-	assert.True(t, exists)
-
-	// Verify parent directories were created
-	dir := filepath.Dir(path)
-	assert.DirExists(t, dir)
+		// Verify file still exists
+		exists, err := afero.Exists(testFs, defaultCfgFile)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
 }
 
 // TestWriteDefault_OutputIsParseable verifies viper output is valid TOML with expected sections.
 func TestWriteDefault_OutputIsParseable(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	path := "/tmp/test-config.toml"
-
-	err := WriteDefault(fs, path, false)
-	require.NoError(t, err)
+	testFs, defaultCfgFile := NewTestFsWithDefaultFile(t)
 
 	// Read file content directly and verify it's valid TOML
-	data, err := afero.ReadFile(fs, path)
+	data, err := afero.ReadFile(testFs, defaultCfgFile)
 	require.NoError(t, err)
 
-	// Verify we can parse it as TOML and unmarshal to Config
-	var cfg Config
-	require.NoError(t, unmarshalTOML(data, &cfg))
+	require.NoError(t, validateTOML(t, data))
 
 	// Verify all sections are present by checking we can read keys
 	v := viper.New()
-	v.SetFs(fs)
-	v.SetConfigFile(path)
+	v.SetFs(testFs)
+	v.SetConfigFile(defaultCfgFile)
 	v.SetConfigType("toml")
 	require.NoError(t, v.ReadInConfig())
 
@@ -214,21 +158,17 @@ func TestSet_UpdatesValue(t *testing.T) {
 		},
 	}
 
+	testFs, defaultCfgFile := NewTestFsWithDefaultFile(t)
+
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			fs := afero.NewMemMapFs()
-			path := "/tmp/test-config.toml"
-
-			// Create initial config
-			require.NoError(t, WriteDefault(fs, path, false))
-
 			// Update key
-			require.NoError(t, Set(fs, path, tt.key, tt.value))
+			require.NoError(t, Set(testFs, defaultCfgFile, tt.key, tt.value))
 
 			// Re-read and verify
 			v := viper.New()
-			v.SetFs(fs)
-			v.SetConfigFile(path)
+			v.SetFs(testFs)
+			v.SetConfigFile(defaultCfgFile)
 			v.SetConfigType("toml")
 			require.NoError(t, v.ReadInConfig())
 
@@ -237,143 +177,114 @@ func TestSet_UpdatesValue(t *testing.T) {
 	}
 }
 
-// TestSet_UnknownKey verifies error for unknown keys.
-func TestSet_UnknownKey(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	path := "/tmp/test-config.toml"
-
-	require.NoError(t, WriteDefault(fs, path, false))
-
-	err := Set(fs, path, "unknown.key", "value")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown configuration key")
-}
-
 // TestSet_InvalidValue tests various invalid values for type-specific keys.
-func TestSet_InvalidValue(t *testing.T) {
+func TestSet_Invalid(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
-		name        string
-		key         string
-		value       string
-		expectError bool
-		errorText   string
+		name      string
+		key       string
+		value     string
+		errorText string
 	}{
 		{
-			name:        "logging.level invalid",
-			key:         "logging.level",
-			value:       "verbose",
-			expectError: true,
-			errorText:   "must be one of",
+			name:      "unknown key",
+			key:       "unknown.key",
+			value:     "fake",
+			errorText: "unknown configuration key",
 		},
 		{
-			name:        "output.quiet invalid bool",
-			key:         "output.quiet",
-			value:       "maybe",
-			expectError: true,
-			errorText:   "must be 'true' or 'false'",
+			name:      "logging.level invalid",
+			key:       "logging.level",
+			value:     "verbose",
+			errorText: "must be one of",
 		},
 		{
-			name:        "output.default_format invalid",
-			key:         "output.default_format",
-			value:       "xml",
-			expectError: true,
-			errorText:   "must be 'human' or 'json'",
+			name:      "output.quiet invalid bool",
+			key:       "output.quiet",
+			value:     "maybe",
+			errorText: "must be 'true' or 'false'",
 		},
 		{
-			name:        "logging.max_size_mb negative",
-			key:         "logging.max_size_mb",
-			value:       "-1",
-			expectError: true,
-			errorText:   "non-negative integer",
+			name:      "output.default_format invalid",
+			key:       "output.default_format",
+			value:     "xml",
+			errorText: "must be 'human' or 'json'",
 		},
 		{
-			name:        "logging.max_size_mb non-integer",
-			key:         "logging.max_size_mb",
-			value:       "not-a-number",
-			expectError: true,
-			errorText:   "non-negative integer",
+			name:      "logging.max_size_mb negative",
+			key:       "logging.max_size_mb",
+			value:     "-1",
+			errorText: "non-negative integer",
 		},
 		{
-			name:        "logging.max_backups negative",
-			key:         "logging.max_backups",
-			value:       "-1",
-			expectError: true,
-			errorText:   "non-negative integer",
+			name:      "logging.max_size_mb non-integer",
+			key:       "logging.max_size_mb",
+			value:     "not-a-number",
+			errorText: "non-negative integer",
+		},
+		{
+			name:      "logging.max_backups negative",
+			key:       "logging.max_backups",
+			value:     "-1",
+			errorText: "non-negative integer",
 		},
 	}
 
+	testFs, defaultCfgFile := NewTestFsWithDefaultFile(t)
+
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			fs := afero.NewMemMapFs()
-			path := "/tmp/test-config.toml"
+			t.Parallel()
 
-			require.NoError(t, WriteDefault(fs, path, false))
-
-			err := Set(fs, path, tt.key, tt.value)
-			if tt.expectError {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errorText)
-			} else {
-				require.NoError(t, err)
-			}
+			err := Set(testFs, defaultCfgFile, tt.key, tt.value)
+			assert.ErrorContains(t, err, tt.errorText)
 		})
 	}
 }
 
 // TestSet_FileNotFound verifies error when file does not exist.
 func TestSet_FileNotFound(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	path := "/nonexistent/config.toml"
+	testFs, _ := NewTestFs(t)
+	path := "fake/config/path/config.toml"
 
-	err := Set(fs, path, "database.path", "/some/path.db")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "reading config file")
+	err := Set(testFs, path, "database.path", "/some/path.db")
+	assert.ErrorContains(t, err, "reading config file")
 }
 
 // TestCheck_ValidFile verifies Check returns nil for valid TOML.
 func TestCheck_ValidFile(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	path := "/tmp/test-config.toml"
+	testFs, defaultCfgFile := NewTestFsWithDefaultFile(t)
 
-	// Create valid config via WriteDefault
-	require.NoError(t, WriteDefault(fs, path, false))
+	t.Run("valid toml", func(t *testing.T) {
+		require.NoError(t, Check(testFs, defaultCfgFile))
+	})
 
-	err := Check(fs, path)
-	require.NoError(t, err)
-}
+	t.Run("invalid toml", func(t *testing.T) {
+		invalidCfgFile := filepath.Join(filepath.Dir(defaultCfgFile), "bad-config.toml")
 
-// TestCheck_InvalidToml verifies Check returns error for malformed TOML.
-func TestCheck_InvalidToml(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	path := "/tmp/bad-config.toml"
+		// Write malformed TOML
+		badContent := "[database\npath = broken"
+		require.NoError(t, afero.WriteFile(testFs, invalidCfgFile, []byte(badContent), 0o644))
 
-	// Write malformed TOML
-	badContent := `[database
-path = "broken"`
-	require.NoError(t, afero.WriteFile(fs, path, []byte(badContent), 0o644))
+		err := Check(testFs, invalidCfgFile)
+		assert.ErrorContains(t, err, "parsing config file")
+	})
 
-	err := Check(fs, path)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "parsing config file")
-}
-
-// TestCheck_FailsValidation verifies Check returns error for TOML with invalid values.
-func TestCheck_FailsValidation(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	path := "/tmp/invalid-config.toml"
-
-	// Write TOML with invalid output format
-	content := `[database]
+	t.Run("invalid value", func(t *testing.T) {
+		badValueFile := filepath.Join(filepath.Dir(defaultCfgFile), "bad-config.toml")
+		// Write TOML with invalid output format
+		content := `[database]
 path = "/valid/db.sqlite"
 
 [output]
 default_format = "xml"
 `
-	require.NoError(t, afero.WriteFile(fs, path, []byte(content), 0o644))
+		require.NoError(t, afero.WriteFile(testFs, badValueFile, []byte(content), 0o644))
 
-	err := Check(fs, path)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "validating config")
+		err := Check(testFs, badValueFile)
+		assert.ErrorContains(t, err, "validating config")
+	})
 }
 
 // TestGetValue_AllKeys tests GetValue for all supported keys.
@@ -479,8 +390,7 @@ func TestGetValue_UnknownKey(t *testing.T) {
 	applyDefaults(cfg)
 
 	_, err := GetValue(cfg, "unknown.key")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown configuration key")
+	require.ErrorContains(t, err, "unknown configuration key")
 }
 
 // TestGetValue_InvalidFormat tests invalid key format.
@@ -490,33 +400,27 @@ func TestGetValue_InvalidFormat(t *testing.T) {
 
 	// Test key without dot separator
 	_, err := GetValue(cfg, "invalid_key")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid key format")
+	require.Error(t, err, "invalid key format")
 
 	// Test key with section that doesn't exist
 	_, err = GetValue(cfg, "nonexistent.field")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown configuration key")
+	require.Error(t, err, "unknown configuration key")
 }
 
 // TestSet_PreservesOtherValues verifies that Set preserves other config values.
 func TestSet_PreservesOtherValues(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	path := "/tmp/test-config.toml"
-
-	// Create initial config
-	require.NoError(t, WriteDefault(fs, path, false))
+	testFs, defaultCfgFile := NewTestFsWithDefaultFile(t)
 
 	// Set one key
-	require.NoError(t, Set(fs, path, "database.path", "/custom/db.sqlite"))
+	require.NoError(t, Set(testFs, defaultCfgFile, "database.path", "/custom/db.sqlite"))
 
 	// Set another key and verify the first is preserved
-	require.NoError(t, Set(fs, path, "output.quiet", "true"))
+	require.NoError(t, Set(testFs, defaultCfgFile, "output.quiet", "true"))
 
 	// Re-read and verify both values
 	v := viper.New()
-	v.SetFs(fs)
-	v.SetConfigFile(path)
+	v.SetFs(testFs)
+	v.SetConfigFile(defaultCfgFile)
 	v.SetConfigType("toml")
 	require.NoError(t, v.ReadInConfig())
 
@@ -526,24 +430,20 @@ func TestSet_PreservesOtherValues(t *testing.T) {
 
 // TestCheck_EmptyFile verifies Check handles empty TOML file gracefully.
 func TestCheck_EmptyFile(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	path := "/tmp/empty-config.toml"
+	testFs, testDir := NewTestFs(t)
 
 	// Write empty file
-	require.NoError(t, afero.WriteFile(fs, path, []byte(""), 0o644))
+	emptyFile, err := afero.TempFile(testFs, testDir, "")
+	require.NoError(t, err)
 
 	// Should not error; empty config gets defaults applied
-	err := Check(fs, path)
+	err = Check(testFs, emptyFile.Name())
 	require.NoError(t, err)
 }
 
 // TestSet_MultipleUpdates verifies sequential Set calls work correctly.
 func TestSet_MultipleUpdates(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	path := "/tmp/test-config.toml"
-
-	// Create initial config
-	require.NoError(t, WriteDefault(fs, path, false))
+	testFs, defaultCfgFile := NewTestFsWithDefaultFile(t)
 
 	// Make multiple updates
 	updates := []struct {
@@ -557,13 +457,13 @@ func TestSet_MultipleUpdates(t *testing.T) {
 	}
 
 	for _, u := range updates {
-		require.NoError(t, Set(fs, path, u.key, u.value))
+		require.NoError(t, Set(testFs, defaultCfgFile, u.key, u.value))
 	}
 
 	// Verify final values
 	v := viper.New()
-	v.SetFs(fs)
-	v.SetConfigFile(path)
+	v.SetFs(testFs)
+	v.SetConfigFile(defaultCfgFile)
 	v.SetConfigType("toml")
 	require.NoError(t, v.ReadInConfig())
 
@@ -574,14 +474,11 @@ func TestSet_MultipleUpdates(t *testing.T) {
 
 // TestWriteDefault_AllKeysPresent verifies all expected keys are in the output.
 func TestWriteDefault_AllKeysPresent(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	path := "/tmp/test-config.toml"
-
-	require.NoError(t, WriteDefault(fs, path, false))
+	testFs, defaultCfgFile := NewTestFsWithDefaultFile(t)
 
 	v := viper.New()
-	v.SetFs(fs)
-	v.SetConfigFile(path)
+	v.SetFs(testFs)
+	v.SetConfigFile(defaultCfgFile)
 	v.SetConfigType("toml")
 	require.NoError(t, v.ReadInConfig())
 
@@ -603,15 +500,14 @@ func TestWriteDefault_AllKeysPresent(t *testing.T) {
 	}
 }
 
-// unmarshalTOML is a helper to unmarshal TOML data using go-toml.
-// This mimics what Check() does internally.
-func unmarshalTOML(data []byte, cfg *Config) error {
-	// Import toml at the top of the test file and use it here
-	// For now, we'll use viper to do the unmarshaling
+func validateTOML(t *testing.T, data []byte) error {
+	t.Helper()
+
+	var cfg Config
+
 	v := viper.New()
 	v.SetConfigType("toml")
-	if err := v.ReadConfig(bytes.NewReader(data)); err != nil {
-		return err
-	}
-	return v.Unmarshal(cfg)
+	require.NoError(t, v.ReadConfig(bytes.NewReader(data)))
+
+	return v.Unmarshal(&cfg)
 }

--- a/internal/database/location.go
+++ b/internal/database/location.go
@@ -268,6 +268,34 @@ func (d *Database) DeleteLocation(ctx context.Context, locationID string) error 
 	return nil
 }
 
+// GetRootLocations retrieves all locations with no parent (top-level),
+// ordered by display_name. Includes system locations (Missing, Borrowed).
+func (d *Database) GetRootLocations(ctx context.Context) ([]*Location, error) {
+	const query = `
+		SELECT
+			location_id,
+			display_name,
+			canonical_name,
+			parent_id,
+			full_path_display,
+			full_path_canonical,
+			depth,
+			is_system,
+			updated_at
+		FROM locations_current
+		WHERE parent_id IS NULL
+		ORDER BY display_name
+	`
+
+	rows, err := d.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query root locations: %w", err)
+	}
+	defer rows.Close()
+
+	return scanLocations(rows)
+}
+
 // GetLocationChildren retrieves all child locations of a parent.
 func (d *Database) GetLocationChildren(ctx context.Context, parentID string) ([]*Location, error) {
 	const query = `

--- a/internal/database/location_test.go
+++ b/internal/database/location_test.go
@@ -303,3 +303,115 @@ func TestGetLocationByCanonicalName_EmptyDatabase(t *testing.T) {
 	require.ErrorIs(t, err, ErrLocationNotFound)
 	assert.Nil(t, loc)
 }
+
+func TestGetRootLocations_EmptyDatabase(t *testing.T) {
+	// NewTestDB has system locations (Missing, Borrowed) created by migrations,
+	// but no user-created locations.
+	db := NewTestDB(t)
+	ctx := context.Background()
+
+	locs, err := db.GetRootLocations(ctx)
+	require.NoError(t, err)
+	// System locations Missing and Borrowed are root locations created by migrations.
+	// Verify they are returned rather than asserting empty.
+	for _, loc := range locs {
+		assert.Nil(t, loc.ParentID, "all returned locations should have nil parent_id")
+	}
+}
+
+func TestGetRootLocations_ReturnsRootsAlphabetically(t *testing.T) {
+	db := NewTestDBWithSeed(t)
+	ctx := context.Background()
+
+	locs, err := db.GetRootLocations(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, locs)
+
+	// Extract display names and verify alphabetical ordering.
+	names := make([]string, len(locs))
+	for i, loc := range locs {
+		names[i] = loc.DisplayName
+	}
+
+	for i := 1; i < len(names); i++ {
+		assert.LessOrEqual(t, names[i-1], names[i],
+			"locations should be sorted alphabetically: %q should come before %q", names[i-1], names[i])
+	}
+
+	// Verify known root locations are present (Workshop and Storage are seeded as roots).
+	var displayNames []string
+	for _, loc := range locs {
+		displayNames = append(displayNames, loc.DisplayName)
+	}
+	assert.Contains(t, displayNames, "Workshop")
+	assert.Contains(t, displayNames, "Storage")
+}
+
+func TestGetRootLocations_ExcludesChildren(t *testing.T) {
+	db := NewTestDBWithSeed(t)
+	ctx := context.Background()
+
+	locs, err := db.GetRootLocations(ctx)
+	require.NoError(t, err)
+
+	// None of the returned locations should have a parent_id set.
+	for _, loc := range locs {
+		assert.Nil(t, loc.ParentID,
+			"GetRootLocations should not return child location %q", loc.DisplayName)
+	}
+
+	// Known child locations must not appear.
+	childNames := []string{"Toolbox", "Workbench", "Shelves", "Bin A", "Bin B"}
+	var returnedNames []string
+	for _, loc := range locs {
+		returnedNames = append(returnedNames, loc.DisplayName)
+	}
+	for _, child := range childNames {
+		assert.NotContains(t, returnedNames, child,
+			"child location %q should not appear in root locations", child)
+	}
+}
+
+func TestGetRootLocations_IncludesSystemLocations(t *testing.T) {
+	db := NewTestDBWithSeed(t)
+	ctx := context.Background()
+
+	locs, err := db.GetRootLocations(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, locs)
+
+	// System locations (Missing, Borrowed) are root locations and must be included.
+	var systemNames []string
+	for _, loc := range locs {
+		if loc.IsSystem {
+			systemNames = append(systemNames, loc.DisplayName)
+		}
+	}
+	assert.Contains(t, systemNames, "Missing")
+	assert.Contains(t, systemNames, "Borrowed")
+}
+
+func TestGetRootLocations_AllFieldsPopulated(t *testing.T) {
+	db := NewTestDBWithSeed(t)
+	ctx := context.Background()
+
+	locs, err := db.GetRootLocations(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, locs)
+
+	for _, loc := range locs {
+		assert.NotEmpty(t, loc.LocationID, "location_id should be populated for %q", loc.DisplayName)
+		assert.NotEmpty(t, loc.DisplayName, "display_name should be populated")
+		assert.NotEmpty(t, loc.CanonicalName, "canonical_name should be populated for %q", loc.DisplayName)
+		assert.Nil(t, loc.ParentID, "parent_id should be nil for root location %q", loc.DisplayName)
+		assert.NotEmpty(t, loc.FullPathDisplay, "full_path_display should be populated for %q", loc.DisplayName)
+		assert.NotEmpty(t, loc.FullPathCanonical, "full_path_canonical should be populated for %q", loc.DisplayName)
+		assert.Equal(t, 0, loc.Depth, "root location %q should have depth 0", loc.DisplayName)
+		assert.NotEmpty(t, loc.UpdatedAt, "updated_at should be populated for %q", loc.DisplayName)
+		// For root locations: full_path_display == display_name and full_path_canonical == canonical_name
+		assert.Equal(t, loc.DisplayName, loc.FullPathDisplay,
+			"root location full_path_display should equal display_name")
+		assert.Equal(t, loc.CanonicalName, loc.FullPathCanonical,
+			"root location full_path_canonical should equal canonical_name")
+	}
+}

--- a/internal/database/search.go
+++ b/internal/database/search.go
@@ -11,10 +11,7 @@ import (
 	"github.com/goccy/go-json"
 )
 
-const (
-	resultTypeItem     = "item"
-	resultTypeLocation = "location"
-)
+const resultTypeItem = "item"
 
 // LocationInfo contains basic information about a location.
 type LocationInfo struct {
@@ -223,7 +220,8 @@ func (d *Database) scanSearchResults(
 // enrichResultsWithLastNonSystemLocation populates LastNonSystemLocation for items in system locations.
 func (d *Database) enrichResultsWithLastNonSystemLocation(ctx context.Context, results []*SearchResult) {
 	for _, result := range results {
-		if result.Type == "item" && (result.IsMissing || result.IsBorrowed || result.IsLoaned) && result.ItemID != nil {
+		if result.Type == resultTypeItem && (result.IsMissing || result.IsBorrowed || result.IsLoaned) &&
+			result.ItemID != nil {
 			lastLoc, locErr := d.findLastNonSystemLocation(ctx, *result.ItemID)
 			if locErr == nil && lastLoc != nil {
 				result.LastNonSystemLocation = lastLoc

--- a/mise.toml
+++ b/mise.toml
@@ -67,6 +67,7 @@ run = "go generate ./..."
 [tasks.lint]
 description = "lint project files"
 depends = ["generate"]
+wait_for = ["test"]
 sources = ["**/*.go", ".golangci.yml"]
 outputs = ["bin/golangci-lint.html"]
 run = [


### PR DESCRIPTION
This pull request introduces a new `initialize database` command for first-time setup of the wherehouse SQLite database, including robust backup and overwrite logic, and updates the documentation to reflect this workflow. It also adds comprehensive tests for the new initialization logic, improves code documentation, and refactors the `list` command helpers for clarity.

**Major new feature: Database initialization command**

* Added the `initialize database` subcommand (`wherehouse initialize database`) with support for a `--force` flag to back up and overwrite an existing database. The command ensures directory creation, provides clear output (including JSON and quiet modes), and robustly handles backup filename collisions. (`cmd/initialize/database.go`)
* Introduced the `initialize` command group (`wherehouse initialize`) to organize setup-related commands, with help text and delegation to subcommands. (`cmd/initialize/initialize.go`, `cmd/initialize/doc.go`) [[1]](diffhunk://#diff-9de01e2655839b113adeb07c225f048f4ab24cb30f2c61c177a2a4715f0512b9R1-R29) [[2]](diffhunk://#diff-30199fa6effbae577ca914120f28690897881ff67ba57deba661404678dbbff1R1-R3)

**Testing and reliability improvements**

* Added a comprehensive test suite for the `initialize database` command, covering fresh installs, backup logic, collision handling, JSON/quiet output, and error cases. (`cmd/initialize/database_test.go`)

**Documentation updates**

* Updated the `README.md` to document the new `initialize database` workflow, replacing older `init` references, clarifying usage, and describing backup/overwrite behavior. Also updated command listings and troubleshooting sections to match the new initialization process. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L14-R15) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L182-R201) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L204-R214) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L217-R227) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L250-R260) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L283-R293) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L299-R309) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L349-R359) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R891-R894) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L949-R962) [[11]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1003-R1014)

**Codebase organization and clarity**

* Added package-level documentation for the `list` command and refactored helpers for opening the database and resolving locations, improving maintainability and clarity. (`cmd/list/doc.go`, `cmd/list/helpers.go`) [[1]](diffhunk://#diff-bbf6c6be5e347752c060d730bb1737d148a73586348ce36355deacc151374f3eR1-R21) [[2]](diffhunk://#diff-0fa27bc33908a3df867896d21b9089f669fc3c512e7d1ba6ddd08431e9039b88R1-R23)