### PR TITLE
Add found command and improve development shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ manpages/
 completions/
 release_notes/
 **/mocks/*
+.direnv/

--- a/cmd/found/doc.go
+++ b/cmd/found/doc.go
@@ -1,0 +1,21 @@
+// Package found implements the wherehouse found command,
+// which records that a previously missing or lost item has been found.
+//
+// The found command fires an item.found event, setting the item's current
+// location and establishing (or preserving) its home location for future
+// return tracking.
+//
+// With --return, a second item.moved event is fired to return the item to
+// its home location (TempOriginLocationID) if known.
+//
+// Supported selector types:
+//   - UUID: 550e8400-e29b-41d4-a716-446655440001 (exact ID)
+//   - LOCATION:ITEM: garage:socket (both canonical names, filters by location)
+//   - Canonical name: "10mm socket" (must match exactly 1 item)
+//
+// Examples:
+//
+//	wherehouse found "10mm socket" --in garage
+//	wherehouse found "10mm socket" --in garage --return
+//	wherehouse found garage:screwdriver --in shed --note "behind workbench"
+package found

--- a/cmd/found/found.go
+++ b/cmd/found/found.go
@@ -1,0 +1,43 @@
+package found
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var foundCmd *cobra.Command
+
+// GetFoundCmd returns the found command, initializing it if necessary.
+func GetFoundCmd() *cobra.Command {
+	if foundCmd != nil {
+		return foundCmd
+	}
+
+	foundCmd = &cobra.Command{
+		Use:   "found <item-selector>... --in <location>",
+		Short: "Record that a lost or missing item has been found",
+		Long: `Record that one or more items have been found at a specific location.
+
+The item's home location is NOT changed by default. Use --return to also
+move the item back to its home location immediately.
+
+Selector types:
+  - UUID:          550e8400-e29b-41d4-a716-446655440001
+  - LOCATION:ITEM: garage:socket (both canonical names)
+  - Canonical:     "10mm socket" (must match exactly 1 item)
+
+Examples:
+  wherehouse found "10mm socket" --in garage
+  wherehouse found "10mm socket" --in garage --return
+  wherehouse found garage:screwdriver --in shed --note "behind workbench"`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: runFoundItem,
+	}
+
+	foundCmd.Flags().StringP("in", "i", "", "location where item was found (required)")
+	_ = foundCmd.MarkFlagRequired("in")
+
+	foundCmd.Flags().BoolP("return", "r", false, "also return item to its home location")
+	foundCmd.Flags().StringP("note", "n", "", "optional note for event")
+
+	return foundCmd
+}

--- a/cmd/found/helpers.go
+++ b/cmd/found/helpers.go
@@ -1,0 +1,30 @@
+package found
+
+import (
+	"context"
+
+	"github.com/asphaltbuffet/wherehouse/internal/cli"
+	"github.com/asphaltbuffet/wherehouse/internal/database"
+)
+
+// openDatabase opens the database connection using config settings.
+func openDatabase(ctx context.Context) (*database.Database, error) {
+	return cli.OpenDatabase(ctx)
+}
+
+// resolveLocation attempts to resolve a name or UUID to a location UUID.
+// Accepts either:
+// - Full UUID (verified against database).
+// - Display name or canonical name (looked up in projection).
+func resolveLocation(ctx context.Context, db *database.Database, input string) (string, error) {
+	return cli.ResolveLocation(ctx, db, input)
+}
+
+// resolveItemSelector resolves an item selector to an item UUID.
+// Supports three selector types:
+//  1. UUID (exact ID)
+//  2. LOCATION:ITEM (both canonical names, filters by location)
+//  3. Canonical name (must match exactly 1 item)
+func resolveItemSelector(ctx context.Context, db *database.Database, selector string) (string, error) {
+	return cli.ResolveItemSelector(ctx, db, selector, "wherehouse found")
+}

--- a/cmd/found/item.go
+++ b/cmd/found/item.go
@@ -1,0 +1,230 @@
+package found
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/asphaltbuffet/wherehouse/internal/cli"
+	"github.com/asphaltbuffet/wherehouse/internal/database"
+)
+
+// Result represents the result of a single item found operation.
+type Result struct {
+	ItemID        string   `json:"item_id"`
+	DisplayName   string   `json:"display_name"`
+	FoundAt       string   `json:"found_at"`
+	HomeLocation  string   `json:"home_location"`
+	Returned      bool     `json:"returned"`
+	FoundEventID  int64    `json:"found_event_id"`
+	ReturnEventID *int64   `json:"return_event_id,omitempty"`
+	Warnings      []string `json:"warnings,omitempty"`
+}
+
+// runFoundItem is the main entry point for the found command.
+func runFoundItem(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	foundLocationStr, _ := cmd.Flags().GetString("in")
+	returnToHome, _ := cmd.Flags().GetBool("return")
+	note, _ := cmd.Flags().GetString("note")
+
+	db, err := openDatabase(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to open database: %w", err)
+	}
+	defer db.Close()
+
+	actorUserID := cli.GetActorUserID(ctx)
+
+	foundLocationID, err := resolveLocation(ctx, db, foundLocationStr)
+	if err != nil {
+		return fmt.Errorf("found location not found: %w", err)
+	}
+
+	if sysErr := validateNotSystemLocation(ctx, db, foundLocationID); sysErr != nil {
+		return sysErr
+	}
+
+	cfg := cli.MustGetConfig(ctx)
+	out := cli.NewOutputWriterFromConfig(cmd.OutOrStdout(), cmd.ErrOrStderr(), cfg)
+
+	var results []Result
+
+	for _, selector := range args {
+		itemID, itemErr := resolveItemSelector(ctx, db, selector)
+		if itemErr != nil {
+			return fmt.Errorf("failed to resolve %q: %w", selector, itemErr)
+		}
+
+		result, foundErr := foundItem(ctx, db, itemID, foundLocationID, returnToHome, actorUserID, note)
+		if foundErr != nil {
+			return fmt.Errorf("failed to record found for %q: %w", selector, foundErr)
+		}
+
+		results = append(results, *result)
+
+		if !cfg.IsJSON() {
+			out.Success(formatSuccessMessage(result))
+
+			for _, w := range result.Warnings {
+				out.Warning(w)
+			}
+		}
+	}
+
+	if cfg.IsJSON() {
+		output := map[string]any{"found": results}
+		if jsonErr := out.JSON(output); jsonErr != nil {
+			return fmt.Errorf("failed to encode JSON output: %w", jsonErr)
+		}
+	}
+
+	return nil
+}
+
+// foundItem performs a single item found operation, firing the item.found event
+// and optionally a follow-up item.moved event when --return is used.
+func foundItem(
+	ctx context.Context,
+	db *database.Database,
+	itemID, foundLocationID string,
+	returnToHome bool,
+	actorUserID, note string,
+) (*Result, error) {
+	// Get current item state
+	item, err := db.GetItem(ctx, itemID)
+	if err != nil {
+		return nil, fmt.Errorf("item not found: %w", err)
+	}
+
+	// Get current item location for warning checks
+	currentLoc, err := db.GetLocation(ctx, item.LocationID)
+	if err != nil {
+		return nil, fmt.Errorf("current location not found: %w", err)
+	}
+
+	// Collect non-fatal warnings about the item's current state
+	var warnings []string
+
+	switch {
+	case currentLoc.IsSystem && currentLoc.CanonicalName == "missing":
+		// Normal case: item is at Missing - no warning needed
+	case currentLoc.IsSystem:
+		// Item is at a non-Missing system location (e.g. Borrowed)
+		warnings = append(warnings, fmt.Sprintf(
+			"item is currently at system location %q (not Missing)", currentLoc.DisplayName))
+	default:
+		// Item is at a normal (non-system) location
+		warnings = append(warnings, fmt.Sprintf(
+			"item is not currently missing (currently at %q)", currentLoc.DisplayName))
+	}
+
+	// Determine home location for the item.found event payload.
+	// If TempOriginLocationID is NULL, use foundLocationID as a safe fallback
+	// so the event handler always receives a valid home_location_id.
+	homeLocationID := foundLocationID
+	if item.TempOriginLocationID != nil {
+		homeLocationID = *item.TempOriginLocationID
+	}
+
+	// Get location display names for the result
+	foundLoc, err := db.GetLocation(ctx, foundLocationID)
+	if err != nil {
+		return nil, fmt.Errorf("found location details not found: %w", err)
+	}
+
+	homeLoc, err := db.GetLocation(ctx, homeLocationID)
+	if err != nil {
+		return nil, fmt.Errorf("home location details not found: %w", err)
+	}
+
+	// Fire item.found event
+	foundPayload := map[string]any{
+		"item_id":           itemID,
+		"found_location_id": foundLocationID,
+		"home_location_id":  homeLocationID,
+	}
+
+	foundEventID, err := db.AppendEvent(ctx, "item.found", actorUserID, foundPayload, note)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create found event: %w", err)
+	}
+
+	result := &Result{
+		ItemID:       itemID,
+		DisplayName:  item.DisplayName,
+		FoundAt:      foundLoc.DisplayName,
+		HomeLocation: homeLoc.DisplayName,
+		Returned:     false,
+		FoundEventID: foundEventID,
+		Warnings:     warnings,
+	}
+
+	// Handle --return flag
+	if returnToHome {
+		switch {
+		case item.TempOriginLocationID == nil:
+			// Home is unknown - skip move, add warning
+			result.Warnings = append(result.Warnings,
+				"home location unknown - could not return item (use move command to return manually)")
+
+		case foundLocationID == homeLocationID:
+			// Already at home - skip move, add note
+			result.Warnings = append(result.Warnings,
+				"already at home location - return skipped")
+
+		default:
+			// Validate from_location matches projection (CRITICAL for event-sourcing)
+			if validateErr := db.ValidateFromLocation(ctx, itemID, foundLocationID); validateErr != nil {
+				return nil, fmt.Errorf("projection validation failed: %w", validateErr)
+			}
+
+			// Fire item.moved rehome event to return to home
+			movePayload := map[string]any{
+				"item_id":          itemID,
+				"from_location_id": foundLocationID,
+				"to_location_id":   homeLocationID,
+				"move_type":        "rehome",
+				"project_action":   "clear",
+			}
+
+			returnEventID, moveErr := db.AppendEvent(ctx, "item.moved", actorUserID, movePayload, note)
+			if moveErr != nil {
+				return nil, fmt.Errorf("failed to create return event: %w", moveErr)
+			}
+
+			result.Returned = true
+			result.ReturnEventID = &returnEventID
+		}
+	}
+
+	return result, nil
+}
+
+// validateNotSystemLocation returns an error if the given location is a system location.
+func validateNotSystemLocation(ctx context.Context, db *database.Database, locationID string) error {
+	loc, err := db.GetLocation(ctx, locationID)
+	if err != nil {
+		return fmt.Errorf("failed to get location: %w", err)
+	}
+
+	if loc.IsSystem {
+		return fmt.Errorf(
+			"cannot record item as found at system location %q\nUse a real location for --in",
+			loc.DisplayName,
+		)
+	}
+
+	return nil
+}
+
+// formatSuccessMessage returns a human-readable success message for a found result.
+func formatSuccessMessage(r *Result) string {
+	if r.Returned {
+		return fmt.Sprintf("Found %q at %s, returned to %s", r.DisplayName, r.FoundAt, r.HomeLocation)
+	}
+
+	return fmt.Sprintf("Found %q at %s (home: %s)", r.DisplayName, r.FoundAt, r.HomeLocation)
+}

--- a/cmd/found/item_test.go
+++ b/cmd/found/item_test.go
@@ -1,0 +1,715 @@
+package found
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/asphaltbuffet/wherehouse/internal/database"
+)
+
+// testIDs holds unique IDs for a test run.
+type testIDs struct {
+	garageID   string
+	shelfID    string
+	toteID     string
+	missingID  string
+	borrowedID string
+	itemID1    string
+	itemID2    string
+	itemID3    string
+}
+
+// setupFoundTest creates a test database with locations and items.
+func setupFoundTest(t *testing.T) (*database.Database, context.Context, testIDs) {
+	t.Helper()
+
+	ctx := context.Background()
+	db, err := database.Open(database.Config{
+		Path:        ":memory:",
+		BusyTimeout: database.DefaultBusyTimeout,
+		AutoMigrate: true,
+	})
+	require.NoError(t, err)
+
+	// Generate unique IDs for this test to avoid constraint violations
+	prefix := uuid.New().String()[:8]
+
+	ids := testIDs{
+		garageID:   uuid.New().String(),
+		shelfID:    uuid.New().String(),
+		toteID:     uuid.New().String(),
+		missingID:  uuid.New().String(),
+		borrowedID: uuid.New().String(),
+		itemID1:    uuid.New().String(),
+		itemID2:    uuid.New().String(),
+		itemID3:    uuid.New().String(),
+	}
+
+	// Create normal locations with unique display names
+	err = db.CreateLocation(ctx, ids.garageID, fmt.Sprintf("Garage-%s", prefix), nil, false, 0, "2025-01-01T00:00:00Z")
+	require.NoError(t, err)
+	err = db.CreateLocation(
+		ctx,
+		ids.shelfID,
+		fmt.Sprintf("Shelf-%s", prefix),
+		nil,
+		false,
+		0,
+		"2025-01-01T00:00:01Z",
+	)
+	require.NoError(t, err)
+	err = db.CreateLocation(ctx, ids.toteID, fmt.Sprintf("Tote F-%s", prefix), nil, false, 0, "2025-01-01T00:00:02Z")
+	require.NoError(t, err)
+
+	// System locations (Missing and Borrowed) are automatically created by seedSystemLocations()
+	// during database initialization. We just need to retrieve them.
+	missingLoc, err := db.GetLocationByCanonicalName(ctx, "missing")
+	require.NoError(t, err)
+	require.NotNil(t, missingLoc)
+	ids.missingID = missingLoc.LocationID
+
+	borrowedLoc, err := db.GetLocationByCanonicalName(ctx, "borrowed")
+	require.NoError(t, err)
+	require.NotNil(t, borrowedLoc)
+	ids.borrowedID = borrowedLoc.LocationID
+
+	// Create items in missing location (typical starting state for found command)
+	err = db.CreateItem(ctx, ids.itemID1, "10mm socket", ids.missingID, 1, "2025-01-01T00:00:05Z")
+	require.NoError(t, err)
+	err = db.CreateItem(ctx, ids.itemID2, "wrench", ids.missingID, 2, "2025-01-01T00:00:06Z")
+	require.NoError(t, err)
+	err = db.CreateItem(ctx, ids.itemID3, "hammer", ids.missingID, 3, "2025-01-01T00:00:07Z")
+	require.NoError(t, err)
+
+	return db, ctx, ids
+}
+
+// =====================================================================
+// HAPPY PATH TESTS
+// =====================================================================
+
+// Test 1: Basic found - item at Missing, found at valid location, no return.
+func TestFoundItem_ItemAtMissing_Success(t *testing.T) {
+	db, ctx, ids := setupFoundTest(t)
+	defer db.Close()
+
+	result, err := foundItem(ctx, db, ids.itemID1, ids.garageID, false, "testuser", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify result structure
+	assert.Equal(t, ids.itemID1, result.ItemID)
+	assert.Equal(t, "10mm socket", result.DisplayName)
+	assert.Positive(t, result.FoundEventID)
+	assert.False(t, result.Returned)
+	assert.Nil(t, result.ReturnEventID)
+	assert.Empty(t, result.Warnings) // No warning for item at Missing
+
+	// Verify item projection was updated
+	item, err := db.GetItem(ctx, ids.itemID1)
+	require.NoError(t, err)
+	require.NotNil(t, item)
+
+	assert.Equal(t, ids.garageID, item.LocationID)
+	assert.True(t, item.InTemporaryUse)
+	assert.NotNil(t, item.TempOriginLocationID)
+}
+
+// Test 2: Found + return - item at Missing with known home, returns to home.
+func TestFoundItem_WithReturn_Success(t *testing.T) {
+	db, ctx, ids := setupFoundTest(t)
+	defer db.Close()
+
+	// Use a temporary_use move to establish home location properly
+	// Move item from Missing to Tote F with temporary_use
+	tempMovePayload := map[string]any{
+		"item_id":          ids.itemID1,
+		"from_location_id": ids.missingID,
+		"to_location_id":   ids.toteID,
+		"move_type":        "temporary_use",
+		"project_action":   "clear",
+	}
+	_, err := db.AppendEvent(ctx, "item.moved", "testuser", tempMovePayload, "")
+	require.NoError(t, err)
+
+	// Now move from Tote F to Shelf (still in temporary use, origin stays Missing)
+	tempMovePayload2 := map[string]any{
+		"item_id":          ids.itemID1,
+		"from_location_id": ids.toteID,
+		"to_location_id":   ids.shelfID,
+		"move_type":        "temporary_use",
+		"project_action":   "clear",
+	}
+	_, err = db.AppendEvent(ctx, "item.moved", "testuser", tempMovePayload2, "")
+	require.NoError(t, err)
+
+	// Move back to Missing to simulate found state
+	normalMovePayload := map[string]any{
+		"item_id":          ids.itemID1,
+		"from_location_id": ids.shelfID,
+		"to_location_id":   ids.missingID,
+		"move_type":        "normal",
+		"project_action":   "clear",
+	}
+	_, err = db.AppendEvent(ctx, "item.moved", "testuser", normalMovePayload, "")
+	require.NoError(t, err)
+
+	// Get item to verify TempOriginLocationID is set to Missing
+	item, err := db.GetItem(ctx, ids.itemID1)
+	require.NoError(t, err)
+	require.NotNil(t, item.TempOriginLocationID)
+	assert.Equal(t, ids.missingID, *item.TempOriginLocationID)
+
+	// Now find it at garage and return it (should go back to Missing)
+	result, err := foundItem(ctx, db, ids.itemID1, ids.garageID, true, "testuser", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify both events were fired
+	assert.Equal(t, ids.itemID1, result.ItemID)
+	assert.Positive(t, result.FoundEventID)
+	assert.True(t, result.Returned)
+	assert.NotNil(t, result.ReturnEventID)
+	assert.Greater(t, *result.ReturnEventID, result.FoundEventID)
+	assert.Empty(t, result.Warnings) // No warning for item at Missing with known home
+
+	// Verify final item location is back at Missing
+	finalItem, err := db.GetItem(ctx, ids.itemID1)
+	require.NoError(t, err)
+	require.NotNil(t, finalItem)
+
+	assert.Equal(t, ids.missingID, finalItem.LocationID)
+	assert.False(t, finalItem.InTemporaryUse)
+	assert.Nil(t, finalItem.TempOriginLocationID)
+}
+
+// Test 3: Found + return, already at home - skips move, adds note.
+func TestFoundItem_WithReturn_AlreadyAtHome(t *testing.T) {
+	db, ctx, ids := setupFoundTest(t)
+	defer db.Close()
+
+	// Use item.found to set the temp_origin_location_id to the found location
+	foundPayload1 := map[string]any{
+		"item_id":           ids.itemID1,
+		"found_location_id": ids.garageID,
+		"home_location_id":  ids.garageID,
+	}
+	_, err := db.AppendEvent(ctx, "item.found", "testuser", foundPayload1, "")
+	require.NoError(t, err)
+
+	// Get item to verify TempOriginLocationID is set to Garage
+	item, err := db.GetItem(ctx, ids.itemID1)
+	require.NoError(t, err)
+	require.Equal(t, ids.garageID, item.LocationID)
+	require.NotNil(t, item.TempOriginLocationID)
+	assert.Equal(t, ids.garageID, *item.TempOriginLocationID)
+
+	// Now find it again at garage with --return
+	// Since foundLocationID (Garage) == homeLocationID (Garage from temp_origin), should skip move
+	result, err := foundItem(ctx, db, ids.itemID1, ids.garageID, true, "testuser", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify only one found event, no return event
+	assert.False(t, result.Returned)
+	assert.Nil(t, result.ReturnEventID)
+
+	// Verify warnings: first from initial state check (not at missing), then from --return check
+	require.Len(t, result.Warnings, 2)
+	assert.Contains(t, result.Warnings[0], "item is not currently missing")
+	assert.Contains(t, result.Warnings[1], "already at home location")
+}
+
+// Test 4: Found + return with NULL home - fires found, skips move, warns.
+func TestFoundItem_WithReturn_NullHome(t *testing.T) {
+	db, ctx, ids := setupFoundTest(t)
+	defer db.Close()
+
+	// Item is at Missing with no TempOriginLocationID (NULL home)
+	// This is the default state for items created in Missing
+
+	result, err := foundItem(ctx, db, ids.itemID1, ids.garageID, true, "testuser", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify found event only, no return event
+	assert.Positive(t, result.FoundEventID)
+	assert.False(t, result.Returned)
+	assert.Nil(t, result.ReturnEventID)
+
+	// Verify warning about unknown home
+	assert.NotEmpty(t, result.Warnings)
+	assert.NotEmpty(t, result.Warnings)
+	assert.Contains(t, result.Warnings[0], "home location unknown")
+}
+
+// =====================================================================
+// WARNING CASES (warn and proceed)
+// =====================================================================
+
+// Test 5: Warning - item at normal location (not Missing).
+func TestFoundItem_ItemAtNormalLocation_Warns(t *testing.T) {
+	db, ctx, ids := setupFoundTest(t)
+	defer db.Close()
+
+	// Move item from Missing to Garage (establish it as not at Missing)
+	movePayload := map[string]any{
+		"item_id":          ids.itemID1,
+		"from_location_id": ids.missingID,
+		"to_location_id":   ids.garageID,
+		"move_type":        "normal",
+		"project_action":   "clear",
+	}
+	_, err := db.AppendEvent(ctx, "item.moved", "testuser", movePayload, "")
+	require.NoError(t, err)
+
+	// Now find it (still at garage, not missing)
+	result, err := foundItem(ctx, db, ids.itemID1, ids.shelfID, false, "testuser", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify found event was still created despite warning
+	assert.Positive(t, result.FoundEventID)
+
+	// Verify warning about item not being missing
+	assert.NotEmpty(t, result.Warnings)
+	assert.Contains(t, result.Warnings[0], "item is not currently missing")
+}
+
+// Test 6: Warning - item at Borrowed (system, non-Missing).
+func TestFoundItem_ItemAtBorrowed_Warns(t *testing.T) {
+	db, ctx, ids := setupFoundTest(t)
+	defer db.Close()
+
+	// Move item from Missing to Borrowed
+	movePayload := map[string]any{
+		"item_id":          ids.itemID1,
+		"from_location_id": ids.missingID,
+		"to_location_id":   ids.borrowedID,
+		"move_type":        "normal",
+		"project_action":   "clear",
+	}
+	_, err := db.AppendEvent(ctx, "item.moved", "testuser", movePayload, "")
+	require.NoError(t, err)
+
+	// Now find it (at Borrowed)
+	result, err := foundItem(ctx, db, ids.itemID1, ids.garageID, false, "testuser", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify found event was created
+	assert.Positive(t, result.FoundEventID)
+
+	// Verify warning about system location
+	assert.NotEmpty(t, result.Warnings)
+	assert.Contains(t, result.Warnings[0], "item is currently at system location")
+}
+
+// =====================================================================
+// ERROR CASES (hard fail)
+// =====================================================================
+
+// Test 7: Error - item selector not found.
+func TestFoundItem_ItemNotFound_Error(t *testing.T) {
+	db, ctx, ids := setupFoundTest(t)
+	defer db.Close()
+
+	nonExistentID := uuid.New().String()
+	result, err := foundItem(ctx, db, nonExistentID, ids.garageID, false, "testuser", "")
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "item not found")
+}
+
+// Test 8: Error - found location (--in) is Missing (system location).
+func TestFoundItem_FoundAtSystemLocationMissing_Error(t *testing.T) {
+	db, ctx, ids := setupFoundTest(t)
+	defer db.Close()
+
+	err := validateNotSystemLocation(ctx, db, ids.missingID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot record item as found at system location")
+}
+
+// Test 9: Error - found location (--in) is Borrowed (system location).
+func TestFoundItem_FoundAtSystemLocationBorrowed_Error(t *testing.T) {
+	db, ctx, ids := setupFoundTest(t)
+	defer db.Close()
+
+	err := validateNotSystemLocation(ctx, db, ids.borrowedID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot record item as found at system location")
+}
+
+// =====================================================================
+// EVENT STATE VERIFICATION TESTS
+// =====================================================================
+
+// Test 10: item.found sets in_temporary_use flag.
+func TestFoundItem_SetsInTemporaryUse(t *testing.T) {
+	db, ctx, ids := setupFoundTest(t)
+	defer db.Close()
+
+	result, err := foundItem(ctx, db, ids.itemID1, ids.garageID, false, "testuser", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	item, err := db.GetItem(ctx, ids.itemID1)
+	require.NoError(t, err)
+	require.NotNil(t, item)
+
+	assert.True(t, item.InTemporaryUse)
+}
+
+// Test 11: item.found sets temp_origin_location_id.
+func TestFoundItem_SetsTemporaryOrigin(t *testing.T) {
+	db, ctx, ids := setupFoundTest(t)
+	defer db.Close()
+
+	result, err := foundItem(ctx, db, ids.itemID1, ids.garageID, false, "testuser", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	item, err := db.GetItem(ctx, ids.itemID1)
+	require.NoError(t, err)
+	require.NotNil(t, item)
+
+	// Home should be fallback to found location (since item had NULL TempOriginLocationID)
+	assert.NotNil(t, item.TempOriginLocationID)
+	assert.Equal(t, ids.garageID, *item.TempOriginLocationID)
+}
+
+// Test 12: item.found + item.moved clears temp state.
+func TestFoundItem_WithReturn_ClearsTempState(t *testing.T) {
+	db, ctx, ids := setupFoundTest(t)
+	defer db.Close()
+
+	// Establish home location using temporary_use
+	tempMovePayload := map[string]any{
+		"item_id":          ids.itemID1,
+		"from_location_id": ids.missingID,
+		"to_location_id":   ids.toteID,
+		"move_type":        "temporary_use",
+		"project_action":   "clear",
+	}
+	_, err := db.AppendEvent(ctx, "item.moved", "testuser", tempMovePayload, "")
+	require.NoError(t, err)
+
+	// Move back to Missing
+	normalMovePayload := map[string]any{
+		"item_id":          ids.itemID1,
+		"from_location_id": ids.toteID,
+		"to_location_id":   ids.missingID,
+		"move_type":        "normal",
+		"project_action":   "clear",
+	}
+	_, err = db.AppendEvent(ctx, "item.moved", "testuser", normalMovePayload, "")
+	require.NoError(t, err)
+
+	// Verify state before found
+	itemBefore, err := db.GetItem(ctx, ids.itemID1)
+	require.NoError(t, err)
+	assert.True(t, itemBefore.InTemporaryUse)
+	assert.NotNil(t, itemBefore.TempOriginLocationID)
+
+	result, err := foundItem(ctx, db, ids.itemID1, ids.garageID, true, "testuser", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.Returned)
+
+	// After return move, verify temp state is cleared
+	item, err := db.GetItem(ctx, ids.itemID1)
+	require.NoError(t, err)
+	require.NotNil(t, item)
+
+	assert.False(t, item.InTemporaryUse)
+	assert.Nil(t, item.TempOriginLocationID)
+}
+
+// Test 13: Event log has correct count.
+func TestFoundItem_EventCount(t *testing.T) {
+	db, ctx, ids := setupFoundTest(t)
+	defer db.Close()
+
+	// Count events before
+	var countBefore int64
+	err := db.DB().QueryRowContext(ctx, "SELECT COUNT(*) FROM events").Scan(&countBefore)
+	require.NoError(t, err)
+
+	// Found without return = 1 event
+	result, err := foundItem(ctx, db, ids.itemID1, ids.garageID, false, "testuser", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	var countAfter int64
+	err = db.DB().QueryRowContext(ctx, "SELECT COUNT(*) FROM events").Scan(&countAfter)
+	require.NoError(t, err)
+
+	assert.Equal(t, countBefore+1, countAfter, "Expected 1 event for found without return")
+
+	// Now test with return
+	// Establish home with temporary_use move
+	tempMovePayload := map[string]any{
+		"item_id":          ids.itemID2,
+		"from_location_id": ids.missingID,
+		"to_location_id":   ids.toteID,
+		"move_type":        "temporary_use",
+		"project_action":   "clear",
+	}
+	_, err = db.AppendEvent(ctx, "item.moved", "testuser", tempMovePayload, "")
+	require.NoError(t, err)
+
+	normalMovePayload := map[string]any{
+		"item_id":          ids.itemID2,
+		"from_location_id": ids.toteID,
+		"to_location_id":   ids.missingID,
+		"move_type":        "normal",
+		"project_action":   "clear",
+	}
+	_, err = db.AppendEvent(ctx, "item.moved", "testuser", normalMovePayload, "")
+	require.NoError(t, err)
+
+	var countBeforeReturn int64
+	err = db.DB().QueryRowContext(ctx, "SELECT COUNT(*) FROM events").Scan(&countBeforeReturn)
+	require.NoError(t, err)
+
+	// Found with return = 2 events
+	result2, err := foundItem(ctx, db, ids.itemID2, ids.garageID, true, "testuser", "")
+	require.NoError(t, err)
+	require.NotNil(t, result2)
+	require.True(t, result2.Returned)
+
+	var countAfterReturn int64
+	err = db.DB().QueryRowContext(ctx, "SELECT COUNT(*) FROM events").Scan(&countAfterReturn)
+	require.NoError(t, err)
+
+	assert.Equal(t, countBeforeReturn+2, countAfterReturn, "Expected 2 events for found with return")
+}
+
+// =====================================================================
+// EDGE CASES
+// =====================================================================
+
+// Test 14: Item already at found location (not Missing).
+func TestFoundItem_ItemAlreadyAtFoundLocation_Warns(t *testing.T) {
+	db, ctx, ids := setupFoundTest(t)
+	defer db.Close()
+
+	// Move item to garage
+	movePayload := map[string]any{
+		"item_id":          ids.itemID1,
+		"from_location_id": ids.missingID,
+		"to_location_id":   ids.garageID,
+		"move_type":        "normal",
+		"project_action":   "clear",
+	}
+	_, err := db.AppendEvent(ctx, "item.moved", "testuser", movePayload, "")
+	require.NoError(t, err)
+
+	// Find it at garage (where it already is)
+	result, err := foundItem(ctx, db, ids.itemID1, ids.garageID, false, "testuser", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Should still fire event despite location unchanged
+	assert.Positive(t, result.FoundEventID)
+
+	// Should warn about not being missing
+	assert.NotEmpty(t, result.Warnings)
+	assert.Contains(t, result.Warnings[0], "item is not currently missing")
+}
+
+// Test 15: With note - event is created with note.
+func TestFoundItem_WithNote_EventCreated(t *testing.T) {
+	db, ctx, ids := setupFoundTest(t)
+	defer db.Close()
+
+	note := "found behind workbench"
+	result, err := foundItem(ctx, db, ids.itemID1, ids.garageID, false, "testuser", note)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify event was created (note acceptance is implicit)
+	assert.Positive(t, result.FoundEventID)
+}
+
+// Test 16: Different actors create events with correct attribution.
+func TestFoundItem_DifferentActors_EventCreated(t *testing.T) {
+	db, ctx, ids := setupFoundTest(t)
+	defer db.Close()
+
+	actors := []string{"alice", "bob", "charlie"}
+	for i, actor := range actors {
+		itemID := ids.itemID1
+		switch i {
+		case 1:
+			itemID = ids.itemID2
+		case 2:
+			itemID = ids.itemID3
+		}
+
+		result, err := foundItem(ctx, db, itemID, ids.garageID, false, actor, "")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Positive(t, result.FoundEventID)
+	}
+}
+
+// =====================================================================
+// OUTPUT FORMAT TESTS
+// =====================================================================
+
+// Test 17: Result struct marshals to JSON correctly.
+func TestResult_JSONMarshal(t *testing.T) {
+	result := &Result{
+		ItemID:       "550e8400-e29b-41d4-a716-446655440000",
+		DisplayName:  "10mm socket",
+		FoundAt:      "Garage",
+		HomeLocation: "Tote F",
+		Returned:     false,
+		FoundEventID: 42,
+	}
+
+	// Marshal to JSON
+	jsonBytes, err := json.Marshal(result)
+	require.NoError(t, err)
+
+	// Unmarshal to verify structure
+	var unmarshaled map[string]any
+	err = json.Unmarshal(jsonBytes, &unmarshaled)
+	require.NoError(t, err)
+
+	// Verify fields
+	assert.Equal(t, "550e8400-e29b-41d4-a716-446655440000", unmarshaled["item_id"])
+	assert.Equal(t, "10mm socket", unmarshaled["display_name"])
+	assert.Equal(t, "Garage", unmarshaled["found_at"])
+	assert.Equal(t, "Tote F", unmarshaled["home_location"])
+	assert.False(t, unmarshaled["returned"].(bool))
+	assert.InDelta(t, float64(42), unmarshaled["found_event_id"], 0.1)
+}
+
+// Test 18: Result struct has correct JSON field names.
+func TestResult_JSONFieldNames(t *testing.T) {
+	result := &Result{
+		ItemID:        "test-id",
+		DisplayName:   "test-item",
+		FoundAt:       "test-location",
+		HomeLocation:  "test-home",
+		Returned:      true,
+		FoundEventID:  99,
+		ReturnEventID: intPtr(100),
+	}
+
+	jsonBytes, err := json.Marshal(result)
+	require.NoError(t, err)
+
+	jsonStr := string(jsonBytes)
+	assert.Contains(t, jsonStr, "item_id")
+	assert.Contains(t, jsonStr, "display_name")
+	assert.Contains(t, jsonStr, "found_at")
+	assert.Contains(t, jsonStr, "home_location")
+	assert.Contains(t, jsonStr, "returned")
+	assert.Contains(t, jsonStr, "found_event_id")
+	assert.Contains(t, jsonStr, "return_event_id")
+}
+
+// Test 19: JSON output includes warnings array.
+func TestResult_JSONWithWarnings(t *testing.T) {
+	result := &Result{
+		ItemID:       "test-id",
+		DisplayName:  "test-item",
+		FoundAt:      "Garage",
+		HomeLocation: "Garage",
+		Returned:     false,
+		FoundEventID: 42,
+		Warnings:     []string{"home location unknown - could not return item (use move command to return manually)"},
+	}
+
+	jsonBytes, err := json.Marshal(result)
+	require.NoError(t, err)
+
+	var unmarshaled map[string]any
+	err = json.Unmarshal(jsonBytes, &unmarshaled)
+	require.NoError(t, err)
+
+	// Verify warnings are present
+	warnings, ok := unmarshaled["warnings"]
+	assert.True(t, ok)
+	assert.NotEmpty(t, warnings)
+}
+
+// Test 20: JSON output with return event ID.
+func TestResult_JSONWithReturnEventID(t *testing.T) {
+	returnEventID := int64(43)
+	result := &Result{
+		ItemID:        "test-id",
+		DisplayName:   "test-item",
+		FoundAt:       "Garage",
+		HomeLocation:  "Tote F",
+		Returned:      true,
+		FoundEventID:  42,
+		ReturnEventID: &returnEventID,
+	}
+
+	jsonBytes, err := json.Marshal(result)
+	require.NoError(t, err)
+
+	var unmarshaled map[string]any
+	err = json.Unmarshal(jsonBytes, &unmarshaled)
+	require.NoError(t, err)
+
+	// Verify return event ID is present and has correct value
+	assert.InDelta(t, float64(43), unmarshaled["return_event_id"], 0.1)
+}
+
+// Test 21: Success message formatting without return.
+func TestFormatSuccessMessage_WithoutReturn(t *testing.T) {
+	result := &Result{
+		DisplayName:  "10mm socket",
+		FoundAt:      "Garage",
+		HomeLocation: "Tote F",
+		Returned:     false,
+	}
+
+	msg := formatSuccessMessage(result)
+	assert.Contains(t, msg, "Found")
+	assert.Contains(t, msg, "10mm socket")
+	assert.Contains(t, msg, "Garage")
+	assert.Contains(t, msg, "Tote F")
+	assert.Contains(t, msg, "home:")
+	assert.NotContains(t, msg, "returned to")
+}
+
+// Test 22: Success message formatting with return.
+func TestFormatSuccessMessage_WithReturn(t *testing.T) {
+	result := &Result{
+		DisplayName:  "10mm socket",
+		FoundAt:      "Garage",
+		HomeLocation: "Tote F",
+		Returned:     true,
+	}
+
+	msg := formatSuccessMessage(result)
+	assert.Contains(t, msg, "Found")
+	assert.Contains(t, msg, "10mm socket")
+	assert.Contains(t, msg, "Garage")
+	assert.Contains(t, msg, "Tote F")
+	assert.Contains(t, msg, "returned to")
+	assert.NotContains(t, msg, "home:")
+}
+
+// =====================================================================
+// HELPER FUNCTION
+// =====================================================================
+
+// intPtr returns a pointer to an int64 value (helper for tests).
+func intPtr(i int64) *int64 {
+	return &i
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/asphaltbuffet/wherehouse/cmd/add"
 	configpkg "github.com/asphaltbuffet/wherehouse/cmd/config"
 	"github.com/asphaltbuffet/wherehouse/cmd/find"
+	"github.com/asphaltbuffet/wherehouse/cmd/found"
 	"github.com/asphaltbuffet/wherehouse/cmd/history"
 	"github.com/asphaltbuffet/wherehouse/cmd/initialize"
 	listcmd "github.com/asphaltbuffet/wherehouse/cmd/list"
@@ -62,6 +63,7 @@ Examples:
 	rootCmd.AddCommand(configpkg.GetConfigCmd())
 	rootCmd.AddCommand(add.GetAddCmd())
 	rootCmd.AddCommand(find.GetFindCmd())
+	rootCmd.AddCommand(found.GetFoundCmd())
 	rootCmd.AddCommand(history.GetHistoryCmd())
 	rootCmd.AddCommand(initialize.GetInitializeCmd())
 	rootCmd.AddCommand(listcmd.GetListCmd())

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nur",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -43,17 +64,52 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771923393,
-        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
+        "lastModified": 1772197845,
+        "narHash": "sha256-olbCBhg8OuVcaQGQGmxTf/1d0zJ9v4bZAGRQzvZ/pnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
+        "rev": "50aa2a9fc5fc9bde7170a167a74b6c357e714ac3",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable-small",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nur": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1772229387,
+        "narHash": "sha256-1K0xHgdpBjkpGI6y3+ADoAjPcLQcmvWezBHdFH2QMOc=",
+        "owner": "nix-community",
+        "repo": "NUR",
+        "rev": "e2851f1767a86cce52b91ec3ed1a2d6d27496238",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "NUR",
         "type": "github"
       }
     },
@@ -61,7 +117,8 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "gomod2nix": "gomod2nix",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nur": "nur"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,13 +2,14 @@
   description = "wherehouse - Track your stuff";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
     flake-utils.url = "github:numtide/flake-utils";
     gomod2nix = {
       url = "github:nix-community/gomod2nix";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };
+    nur.url = "github:nix-community/NUR";
   };
 
   outputs = {
@@ -16,12 +17,15 @@
     nixpkgs,
     flake-utils,
     gomod2nix,
+    nur,
+    ...
   }:
     flake-utils.lib.eachDefaultSystem (
       system: let
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [gomod2nix.overlays.default];
+          overlays = [gomod2nix.overlays.default nur.overlays.default];
+          config.allowUnfreePredicate = pkg: builtins.elem (pkgs.lib.getName pkg) ["goreleaser-pro"];
         };
         lib = pkgs.lib;
         version =
@@ -40,6 +44,7 @@
               ./go.sum
               ./gomod2nix.toml
               (lib.fileset.fileFilter (file: lib.hasSuffix ".go" file.name) ./.)
+              (lib.fileset.fileFilter (file: lib.hasSuffix ".sql" file.name) ./.)
             ];
           };
 
@@ -81,15 +86,28 @@
         };
 
         devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs; [
+          packages = with pkgs; [
             go
+            jujutsu
+            jjui
             mise
+            vhs
+            ripgrep
+            fd
+            sd
+            imagemagick
+            gopls
+            nixd
+            pkgs.nur.repos.goreleaser.goreleaser-pro
             gomod2nix.packages.${system}.default
+            self.packages.${system}.default
           ];
 
           shellHook = ''
             mise trust --all
           '';
+
+          CGO_ENABLED = "0";
         };
       }
     )

--- a/internal/database/search.go
+++ b/internal/database/search.go
@@ -262,18 +262,23 @@ func (d *Database) findLastNonSystemLocation(
 	// join with locations_current to filter system locations, and return the most recent.
 	// Using a single query avoids nested connections against the single-connection pool.
 	const query = `
-		SELECT event_type, payload
-		FROM events
-		WHERE item_id = ?
-		  AND event_type IN (
-			'item.created',
-			'item.moved',
-			'item.missing',
-			'item.borrowed',
-			'item.loaned',
-			'item.found'
-		  )
-		ORDER BY event_id DESC
+		SELECT l.location_id, l.display_name, l.full_path_display, l.is_system
+		FROM (
+			SELECT
+				CASE event_type
+					WHEN 'item.created' THEN json_extract(payload, '$.location_id')
+					WHEN 'item.moved'   THEN json_extract(payload, '$.to_location_id')
+					WHEN 'item.found'   THEN json_extract(payload, '$.found_location_id')
+				END AS location_id,
+				event_id
+			FROM events
+			WHERE item_id = ?
+			  AND event_type IN ('item.created', 'item.moved', 'item.found')
+		) extracted
+		JOIN locations_current l ON extracted.location_id = l.location_id
+		WHERE l.is_system = 0
+		ORDER BY extracted.event_id DESC
+		LIMIT 1
 	`
 
 	var loc LocationInfo


### PR DESCRIPTION
This pull request introduces a new `found` command to the CLI, allowing users to record that a previously missing or lost item has been found at a specific location, with optional immediate return to its home location. It includes robust selector support, event firing for item state changes, and user-friendly output with warnings. Additionally, the development environment and Nix flake configuration are improved for better dependency management and developer tooling.

**New `found` command and core logic:**

* Adds a new `found` command (`cmd/found`) to the CLI, supporting item selection by UUID, location:item, or canonical name, and recording the location where an item is found, with an optional `--return` flag to move the item back to its home location if known. This includes help text, examples, and argument parsing. [[1]](diffhunk://#diff-75530af02b18292ddeb4bd97caf7594479eb0d0420e62798345dcc5ee8f74213R1-R21) [[2]](diffhunk://#diff-8ae1d664a73850cc76c295257b2e52683e3a9d1edd6485621817d4f880d7f7f5R1-R43) [[3]](diffhunk://#diff-66017901ab4a093947b355be1cdc2debf3dcb8e212b57c1e2445c9a567ac8cabR1-R230) [[4]](diffhunk://#diff-c3668f7f01f24b34286fda02f901c0e933691d4d7c83aab56510c9b9b538a9a8R1-R30)
* Integrates the `found` command into the CLI by registering it in `cmd/root.go`. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR15) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR66)

**Database and event logic improvements:**

* Refactors the logic for finding the last non-system location for an item, ensuring the new `item.found` event type is handled correctly in event sourcing.

**Development environment and Nix flake enhancements:**

* Updates `.envrc` to use the Nix flake environment and improves `flake.nix` by switching to a smaller Nixpkgs channel, adding extra developer tools, supporting SQL files in the build, and allowing unfree packages like `goreleaser-pro`. [[1]](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430R1) [[2]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L5-R28) [[3]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R47) [[4]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L84-R110)

These changes collectively add a major new feature for item tracking, improve event handling, and streamline the developer experience.