### PR TITLE
Fix release scripting issues

### DIFF
--- a/.mise/tasks/release
+++ b/.mise/tasks/release
@@ -42,7 +42,7 @@ echo ""
 echo "Running safety checks..."
 
 # 1. Clean working copy
-if [ -n "$(jj diff --stat)" ]; then
+if [ -n "$(jj diff -T files)" ]; then
   echo "Error: working copy has uncommitted changes"
   echo "  Run 'jj diff --stat' to see what changed"
   exit 1


### PR DESCRIPTION
This pull request makes a minor update to the release safety check script. It changes the way the script checks for uncommitted changes by using a different `jj diff` flag, which should improve the accuracy of the check.

- Updated the working copy cleanliness check in `.mise/tasks/release` to use `jj diff -T files` instead of `jj diff --stat` for detecting uncommitted changes.