### PR TITLE
Enhance command architecture and add CSV loading feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.0]
+
+### Added
+
+- Add `load` command to add items/locations in bulk
+
 ## [0.1.0] - 2026-02-25
 
 _First release._
@@ -26,4 +32,5 @@ _First release._
 - Use NanoID instead of UUID for item identifiers (shorter, more readable) ([`4772974`](https://github.com/asphaltbuffet/wherehouse/commit/4772974))
 - Unify output styling across all commands ([`0e24808`](https://github.com/asphaltbuffet/wherehouse/commit/0e24808))
 
+[0.2.0]: https://github.com/asphaltbuffet/wherehouse/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/asphaltbuffet/wherehouse/compare/v0.0.0...v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Event-sourced CLI inventory tracker. Go + SQLite. "Where did I put my 10mm socke
 
 | Task | Read first | Key facts (verify before trusting) |
 |---|---|---|
-| New command/subcommand | `ai-docs/knowledge/cli-contract.md` | Pattern: `NewXxxCmd(db xxxDB)` + `NewDefaultXxxCmd()` wired in `cmd/root.go`. Per-command `db.go` defines minimal `xxxDB` interface + `//go:generate mockery`. Register in `cmd/root.go` via `NewDefaultXxxCmd()`. |
+| New command/subcommand | `ai-docs/knowledge/cli-contract.md` | Pattern: `NewXxxCmd() *cobra.Command` — no db arg. DB opened inside `RunE` via `cli.OpenDatabase(cmd.Context())`, then passed to `runXxxCore(cmd, args, db)`. Per-command `db.go` defines minimal `xxxDB` interface + `//go:generate mockery`. Register in `cmd/root.go` via `NewXxxCmd()`. |
 | Output format changes | `cmd/root.go`, `internal/cli/output.go` | Global `--json` flag already exists in `cmd/root.go` (`PersistentFlags()`). There is no per-command `--format` flag — `--json` is the global mechanism; adding `--format` would duplicate it. JSON output paths are implemented in most commands. All styles via `appStyles` singleton in `internal/styles/styles.go` — never inline `lipgloss.NewStyle()` in rendering functions. |
 | Data structures / events | `ai-docs/knowledge/events.md`, `ai-docs/knowledge/business-rules.md` | Event types live in `internal/database/eventTypes.go` (iota + `eventTypeByName` map). Adding a new type: add iota entry → regenerate `eventtype_string.go` (`go generate ./internal/database/`) → add case in `internal/database/eventHandler.go`. |
 | Troubleshooting | `ai-docs/knowledge/business-rules.md` | Events immutable, ordered by `event_id` only (timestamps are informational, not unique). Every `ORDER BY` that could tie must include `event_id ASC/DESC` as tiebreaker. System locations (`Missing`, `Borrowed`, `Loaned`) are predefined and immutable. |
@@ -37,7 +37,7 @@ When you search for something that doesn't exist and spend 3+ calls confirming i
 ```
 cmd/                    # CLI commands — one subdir per command
   <cmd>/
-    <cmd>.go            # cobra command: NewXxxCmd(db xxxDB) + NewDefaultXxxCmd()
+    <cmd>.go            # cobra command: NewXxxCmd() — opens DB via cli.OpenDatabase; delegates to runXxxCore(cmd, args, db)
     db.go               # minimal xxxDB interface + //go:generate mockery
     output.go           # rendering helpers (if needed)
     <cmd>_test.go
@@ -90,7 +90,7 @@ To pin a specific version: change to `pkgs.go_1_XX`.
 - `/audit-docs` — after features or fixes
 
 ### Code
-- **Constructor pattern**: every command exposes `NewXxxCmd(db xxxDB)` + `NewDefaultXxxCmd()`. Never pass `*database.DB` directly to a run function.
+- **Constructor pattern**: `NewXxxCmd() *cobra.Command` — no db parameter. Open DB inside `RunE` with `cli.OpenDatabase(cmd.Context())`, then call `runXxxCore(cmd, args, db)` for testability. Never pass `*database.DB` directly to a run function.
 - **Per-command DB interface**: each `cmd/<cmd>/db.go` defines a minimal interface; `//go:generate mockery` directive required.
 - **Enums**: typed `iota` constants only — never switch on bare integers (`exhaustive` linter enforces this).
 - **ORDER BY tiebreakers**: every query that could tie must include `event_id ASC/DESC`.

--- a/README.md
+++ b/README.md
@@ -355,7 +355,8 @@ Project Management:
   project list         Show all projects (coming soon)
   project delete       Remove project (if no items) (coming soon)
 
-Database Operations:
+Data Operations:
+  load ✅              Bulk import locations and items from CSV file(s)
   initialize database ✅  Initialize new database (--force to overwrite with backup)
   doctor               Validate database consistency (partial)
   export               Export events and projections (coming soon)
@@ -415,6 +416,45 @@ wherehouse find --location Borrowed
 
 # Return borrowed item
 wherehouse move "ladder" Garage --rehome
+```
+
+#### Bulk Import from CSV
+
+Bootstrap your inventory from a spreadsheet or export. Create a CSV file with a
+header row and columns `type`, `name`, and `home`:
+
+```csv
+type,name,home
+L,Garage,
+L,Toolbox,Garage
+L,Socket Set,Toolbox
+I,10mm socket wrench,Socket Set
+I,step ladder,Garage
+I,cordless drill,Toolbox
+```
+
+- `type`: `L` = location, `I` = item
+- `name`: display name (required)
+- `home`: parent location for locations (optional), home location for items (required)
+- Locations must appear before items that reference them (single-pass)
+- Blank lines and lines starting with `#` are skipped
+
+```bash
+# Load a single file
+wherehouse load ~/garage.csv
+# → garage.csv: 3 location(s), 3 item(s)
+
+# Load multiple files — each is summarized
+wherehouse load ~/garage.csv ~/workshop.csv
+# → garage.csv: 3 location(s), 3 item(s)
+# → workshop.csv: 2 location(s), 8 item(s)
+
+# Invalid rows are reported but don't stop the import
+# → garage.csv: 2 location(s), 2 item(s), 1 invalid
+# →   Line 4: "cordless drill" — location not found: Toolbox
+
+# JSON output for scripting
+wherehouse load ~/garage.csv --json
 ```
 
 #### Debugging Inconsistencies
@@ -892,6 +932,7 @@ mise run ci
   - [x] Basic output formatting (human-readable, JSON, quiet modes)
   - [x] Flag overrides: `--db`, `--as` override config file values at runtime
   - [x] Clear error when database file is missing (guides user to `initialize database`)
+  - [x] `load` - Bulk import locations and items from CSV file(s)
 
 ### 🚧 In Progress (v0.2.0 - Alpha)
 

--- a/cmd/load/db.go
+++ b/cmd/load/db.go
@@ -1,0 +1,6 @@
+package load
+
+// The load command delegates entirely to cli.LoadCSV which manages its own
+// database connection. No command-level DB interface is needed.
+//
+//go:generate mockery

--- a/cmd/load/doc.go
+++ b/cmd/load/doc.go
@@ -1,0 +1,2 @@
+// Package load implements importing data into wherehouse.
+package load

--- a/cmd/load/load.go
+++ b/cmd/load/load.go
@@ -1,0 +1,76 @@
+package load
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/asphaltbuffet/wherehouse/internal/cli"
+)
+
+// NewLoadCmd returns the load command, initializing it if necessary.
+func NewLoadCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "load <file>...",
+		Short:   "Load locations and items into wherehouse from CSV file(s)",
+		Long:    "Load locations and items into wherehouse from CSV file(s).",
+		Example: "wherehouse load ~/garage.csv ~/workshop.csv",
+		Args:    cobra.MinimumNArgs(1),
+		RunE:    runLoadCore,
+	}
+
+	return cmd
+}
+
+func runLoadCore(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	cfg := cli.MustGetConfig(ctx)
+	out := cli.NewOutputWriterFromConfig(cmd.OutOrStdout(), cmd.ErrOrStderr(), cfg)
+
+	var results []*cli.LoadResult
+	var hardErrs []error
+
+	for _, arg := range args {
+		r, err := cli.LoadCSV(ctx, arg)
+		if err != nil {
+			hardErrs = append(hardErrs, fmt.Errorf("%s: %w", arg, err))
+			continue
+		}
+		results = append(results, r)
+	}
+
+	// Report hard errors (file-level) to stderr.
+	for _, err := range hardErrs {
+		out.Error(err.Error())
+	}
+
+	if len(results) == 0 {
+		return errors.New("no data loaded")
+	}
+
+	if cfg.IsJSON() {
+		return out.JSON(results)
+	}
+
+	// Human-readable: summary line per file + invalid entry details.
+	for _, r := range results {
+		name := filepath.Base(r.Path)
+		summary := fmt.Sprintf("%s: %d location(s), %d item(s)", name, r.LocationCount, r.ItemCount)
+		if len(r.InvalidEntries) > 0 {
+			summary += fmt.Sprintf(", %d invalid", len(r.InvalidEntries))
+		}
+		out.Println(summary)
+
+		for _, inv := range r.InvalidEntries {
+			out.Println(fmt.Sprintf("  Line %d: %q \u2014 %s", inv.Line, inv.Entry, inv.Error))
+		}
+
+		if len(r.InvalidEntries) > 0 {
+			out.Println("")
+		}
+	}
+
+	return nil
+}

--- a/cmd/load/load_test.go
+++ b/cmd/load/load_test.go
@@ -1,0 +1,47 @@
+package load
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/asphaltbuffet/wherehouse/internal/config"
+)
+
+// ctxWithConfig returns a context with a default (zero-value) Config injected.
+// This satisfies MustGetConfig without requiring a real config file.
+func ctxWithConfig() context.Context {
+	return context.WithValue(context.Background(), config.ConfigKey, &config.Config{})
+}
+
+func TestNewLoadCmd(t *testing.T) {
+	cmd := NewLoadCmd()
+	require.NotNil(t, cmd)
+}
+
+func TestRunLoadCore_NoArgs(t *testing.T) {
+	// cobra MinimumNArgs(1) should reject zero args before RunE is called.
+	cmd := NewLoadCmd()
+	cmd.SetArgs([]string{})
+	err := cmd.ExecuteContext(ctxWithConfig())
+	require.Error(t, err)
+}
+
+func TestRunLoadCore_FileNotFound(t *testing.T) {
+	cmd := NewLoadCmd()
+	cmd.SetArgs([]string{"/nonexistent/file.csv"})
+	err := cmd.ExecuteContext(ctxWithConfig())
+	require.Error(t, err)
+}
+
+func TestRunLoadCore_WrongExtension(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "data.txt")
+	require.NoError(t, os.WriteFile(f, []byte(""), 0o600))
+	cmd := NewLoadCmd()
+	cmd.SetArgs([]string{f})
+	err := cmd.ExecuteContext(ctxWithConfig())
+	require.Error(t, err)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/asphaltbuffet/wherehouse/cmd/history"
 	"github.com/asphaltbuffet/wherehouse/cmd/initialize"
 	listcmd "github.com/asphaltbuffet/wherehouse/cmd/list"
+	"github.com/asphaltbuffet/wherehouse/cmd/load"
 	"github.com/asphaltbuffet/wherehouse/cmd/loan"
 	"github.com/asphaltbuffet/wherehouse/cmd/lost"
 	"github.com/asphaltbuffet/wherehouse/cmd/migrate"
@@ -69,6 +70,7 @@ Examples:
 	rootCmd.AddCommand(history.NewHistoryCmd())
 	rootCmd.AddCommand(initialize.NewInitializeCmd())
 	rootCmd.AddCommand(listcmd.NewListCmd())
+	rootCmd.AddCommand(load.NewLoadCmd())
 	rootCmd.AddCommand(loan.NewLoanCmd())
 	rootCmd.AddCommand(lost.NewLostCmd())
 	rootCmd.AddCommand(migrate.NewMigrateCmd())

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -8,13 +8,33 @@ import (
 	"github.com/asphaltbuffet/wherehouse/internal/nanoid"
 )
 
-// AddItems adds a items to the database.
+// addItemsDB is the database interface required by addItems.
+// *database.Database satisfies this interface.
+type addItemsDB interface {
+	LocationItemQuerier
+	ValidateLocationExists(ctx context.Context, locationID string) error
+	AppendEvent(
+		ctx context.Context,
+		eventType database.EventType,
+		actorUserID string,
+		payload any,
+		note string,
+	) (int64, error)
+}
+
+// AddItems adds items to the database.
 func AddItems(ctx context.Context, items []string, location string) error {
 	db, err := OpenDatabase(ctx)
 	if err != nil {
 		return err
 	}
+	defer db.Close()
 
+	return addItems(ctx, db, items, location)
+}
+
+// addItems is the injectable implementation used by AddItems and loadCSV.
+func addItems(ctx context.Context, db addItemsDB, items []string, location string) error {
 	locationID, err := ResolveLocation(ctx, db, location)
 	if err != nil {
 		return fmt.Errorf("invalid location: %w", err)

--- a/internal/cli/load.go
+++ b/internal/cli/load.go
@@ -1,0 +1,210 @@
+package cli
+
+import (
+	"context"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/asphaltbuffet/wherehouse/internal/database"
+)
+
+// LoadResult holds the outcome of loading a single CSV file.
+type LoadResult struct {
+	Path           string         `json:"path"`
+	ItemCount      int            `json:"item_count"`
+	LocationCount  int            `json:"location_count"`
+	InvalidEntries []InvalidEntry `json:"invalid_entries"`
+}
+
+// InvalidEntry records a row that could not be loaded.
+type InvalidEntry struct {
+	Line  int    `json:"line"`  // 1-based, counting the header row as line 1
+	Entry string `json:"entry"` // value of the name field, or empty string if name was missing
+	Error string `json:"error"` // human-readable reason
+}
+
+// loadDB is the combined interface needed to load CSV rows.
+// It satisfies both addLocationsDB and addItemsDB.
+type loadDB interface {
+	Close() error
+	LocationItemQuerier
+	ValidateLocationExists(ctx context.Context, locationID string) error
+	ValidateUniqueLocationName(ctx context.Context, canonicalName string, excludeLocationID *string) error
+	AppendEvent(
+		ctx context.Context,
+		eventType database.EventType,
+		actorUserID string,
+		payload any,
+		note string,
+	) (int64, error)
+}
+
+// LoadCSV parses a CSV file and inserts valid locations and items into the database.
+// It returns a hard error only when the file cannot be opened or has the wrong extension.
+// Individual row problems are recorded as InvalidEntry values in the result.
+//
+// CSV format (header required, column order flexible):
+//
+//	type - "L" (location) or "I" (item)
+//	name - display name (required)
+//	home - parent location name (optional for locations, required for items)
+func LoadCSV(ctx context.Context, fp string) (*LoadResult, error) {
+	abs, err := filepath.Abs(fp)
+	if err != nil {
+		return nil, err
+	}
+
+	if filepath.Ext(abs) != ".csv" {
+		return nil, fmt.Errorf("invalid extension: %q (expected .csv)", filepath.Ext(abs))
+	}
+
+	db, err := OpenDatabase(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	return loadCSV(ctx, db, abs, fp)
+}
+
+// loadCSV is the injectable inner function used by LoadCSV and tests.
+func loadCSV(ctx context.Context, db loadDB, abs, displayPath string) (*LoadResult, error) {
+	f, err := os.Open(abs)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	result := &LoadResult{Path: displayPath}
+	r := csv.NewReader(f)
+	r.FieldsPerRecord = -1
+
+	header, err := r.Read()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return result, nil
+		}
+		return nil, fmt.Errorf("reading header: %w", err)
+	}
+
+	colIndex := buildColIndex(header)
+
+	lineNum := 1 // header was line 1
+	for {
+		lineNum++
+		row, readErr := r.Read()
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			result.InvalidEntries = append(result.InvalidEntries, InvalidEntry{
+				Line:  lineNum,
+				Error: fmt.Sprintf("malformed CSV row: %v", readErr),
+			})
+			continue
+		}
+
+		if isSkippableRow(row) {
+			lineNum--
+			continue
+		}
+
+		rowType := strings.ToUpper(colValue(row, colIndex, "type"))
+		name := colValue(row, colIndex, "name")
+		home := colValue(row, colIndex, "home")
+
+		if inv := validateName(lineNum, name); inv != nil {
+			result.InvalidEntries = append(result.InvalidEntries, *inv)
+			continue
+		}
+
+		locAdded, itemAdded, inv := processRow(ctx, db, lineNum, rowType, name, home)
+		if inv != nil {
+			result.InvalidEntries = append(result.InvalidEntries, *inv)
+			continue
+		}
+		if locAdded {
+			result.LocationCount++
+		}
+		if itemAdded {
+			result.ItemCount++
+		}
+	}
+
+	return result, nil
+}
+
+// buildColIndex maps lowercase trimmed column names to their indices.
+func buildColIndex(header []string) map[string]int {
+	colIndex := make(map[string]int, len(header))
+	for i, colName := range header {
+		colIndex[strings.TrimSpace(strings.ToLower(colName))] = i
+	}
+	return colIndex
+}
+
+// colValue returns the trimmed value of the named column from a row, or "" if absent.
+func colValue(row []string, colIndex map[string]int, name string) string {
+	idx, ok := colIndex[name]
+	if !ok || idx >= len(row) {
+		return ""
+	}
+	return strings.TrimSpace(row[idx])
+}
+
+// isSkippableRow reports whether a row is blank or a comment and should not count toward line numbers.
+func isSkippableRow(row []string) bool {
+	if len(row) == 0 || (len(row) == 1 && strings.TrimSpace(row[0]) == "") {
+		return true
+	}
+	return strings.HasPrefix(strings.TrimSpace(row[0]), "#")
+}
+
+// validateName checks that name is non-empty and contains no ':'.
+// Returns a non-nil *InvalidEntry if validation fails.
+func validateName(lineNum int, name string) *InvalidEntry {
+	if name == "" {
+		return &InvalidEntry{Line: lineNum, Error: "missing name"}
+	}
+	if strings.Contains(name, ":") {
+		return &InvalidEntry{Line: lineNum, Entry: name, Error: "name must not contain ':'"}
+	}
+	return nil
+}
+
+// processRow handles a single validated CSV data row.
+// It dispatches to addLocations or addItems based on rowType.
+// Returns an InvalidEntry if the row cannot be processed, or nil on success.
+// The caller is responsible for updating result counts.
+func processRow(ctx context.Context, db loadDB, lineNum int, rowType, name, home string) (bool, bool, *InvalidEntry) {
+	switch rowType {
+	case "L":
+		_, err := addLocations(ctx, db, []string{name}, home)
+		if err != nil {
+			return false, false, &InvalidEntry{Line: lineNum, Entry: name, Error: err.Error()}
+		}
+		return true, false, nil
+
+	case "I":
+		if home == "" {
+			return false, false, &InvalidEntry{Line: lineNum, Entry: name, Error: "missing home location for item"}
+		}
+		err := addItems(ctx, db, []string{name}, home)
+		if err != nil {
+			return false, false, &InvalidEntry{Line: lineNum, Entry: name, Error: err.Error()}
+		}
+		return false, true, nil
+
+	default:
+		return false, false, &InvalidEntry{
+			Line:  lineNum,
+			Entry: name,
+			Error: fmt.Sprintf("unknown type %q (expected L or I)", rowType),
+		}
+	}
+}

--- a/internal/cli/load_test.go
+++ b/internal/cli/load_test.go
@@ -1,0 +1,490 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/asphaltbuffet/wherehouse/internal/database"
+)
+
+// newTestLoadDB creates a test database for loadCSV tests.
+func newTestLoadDB(t *testing.T) *database.Database {
+	t.Helper()
+	db, err := database.Open(database.Config{
+		Path:        filepath.Join(t.TempDir(), "test.db"),
+		BusyTimeout: database.DefaultBusyTimeout,
+		AutoMigrate: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// writeTestCSV writes a CSV file to a temp directory and returns its absolute path.
+func writeTestCSV(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "test.csv")
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
+	abs, err := filepath.Abs(p)
+	require.NoError(t, err)
+	return abs
+}
+
+// Hard error tests using exported LoadCSV (these don't need a DB).
+
+func TestLoadCSV_WrongExtension(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	wrongFile := filepath.Join(tmpDir, "test.txt")
+	require.NoError(t, os.WriteFile(wrongFile, []byte("type,name,home\n"), 0o600))
+
+	result, err := LoadCSV(context.Background(), wrongFile)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorContains(t, err, "invalid extension")
+}
+
+func TestLoadCSV_FileNotFound(t *testing.T) {
+	t.Parallel()
+	result, err := LoadCSV(context.Background(), "/nonexistent/path/to/file.csv")
+	require.Error(t, err)
+	assert.Nil(t, result)
+	// Error message varies by OS; just check that we got an error.
+}
+
+// Inner function tests using loadCSV directly with a real test DB.
+
+func TestLoadCSV_EmptyFile(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	abs := writeTestCSV(t, "type,name,home\n")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "test.csv", result.Path)
+	assert.Equal(t, 0, result.ItemCount)
+	assert.Equal(t, 0, result.LocationCount)
+	assert.Empty(t, result.InvalidEntries)
+}
+
+func TestLoadCSV_ValidLocationRow(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	abs := writeTestCSV(t, "type,name,home\nL,Garage,\n")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 1, result.LocationCount)
+	assert.Equal(t, 0, result.ItemCount)
+	assert.Empty(t, result.InvalidEntries)
+}
+
+func TestLoadCSV_ValidItemRow(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	// Location must be defined first in the CSV so the item can reference it.
+	abs := writeTestCSV(t, "type,name,home\nL,Garage,\nI,Hammer,Garage\n")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 1, result.LocationCount)
+	assert.Equal(t, 1, result.ItemCount)
+	assert.Empty(t, result.InvalidEntries)
+}
+
+func TestLoadCSV_ItemBeforeLocation(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	// Item row before its home location is created.
+	abs := writeTestCSV(t, "type,name,home\nI,Hammer,Garage\n")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 0, result.LocationCount)
+	assert.Equal(t, 0, result.ItemCount)
+	require.Len(t, result.InvalidEntries, 1)
+
+	inv := result.InvalidEntries[0]
+	assert.Equal(t, 2, inv.Line)
+	assert.Equal(t, "Hammer", inv.Entry)
+	assert.NotEmpty(t, inv.Error)
+}
+
+func TestLoadCSV_MissingName(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	abs := writeTestCSV(t, "type,name,home\nL,,\n")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 0, result.LocationCount)
+	require.Len(t, result.InvalidEntries, 1)
+
+	inv := result.InvalidEntries[0]
+	assert.Equal(t, 2, inv.Line)
+	assert.Contains(t, inv.Error, "missing name")
+}
+
+func TestLoadCSV_UnknownType(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	abs := writeTestCSV(t, "type,name,home\nX,Widget,\n")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 0, result.LocationCount)
+	assert.Equal(t, 0, result.ItemCount)
+	require.Len(t, result.InvalidEntries, 1)
+
+	inv := result.InvalidEntries[0]
+	assert.Equal(t, 2, inv.Line)
+	assert.Equal(t, "Widget", inv.Entry)
+	assert.Contains(t, inv.Error, "unknown type")
+}
+
+func TestLoadCSV_ColonInName(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	abs := writeTestCSV(t, "type,name,home\nL,Ga:rage,\n")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 0, result.LocationCount)
+	require.Len(t, result.InvalidEntries, 1)
+
+	inv := result.InvalidEntries[0]
+	assert.Equal(t, 2, inv.Line)
+	assert.Equal(t, "Ga:rage", inv.Entry)
+	assert.Contains(t, inv.Error, ":")
+}
+
+func TestLoadCSV_BlankAndCommentRowsSkipped(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	// Blank row and comment row should be skipped without counting toward line numbers.
+	// However, the line counter in the code does NOT skip them in the displayed line number,
+	// so we need to account for that behavior.
+	csv := `type,name,home
+
+# This is a comment
+L,Garage,
+`
+	abs := writeTestCSV(t, csv)
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// The blank row on line 2 is skipped (lineNum-- happens),
+	// the comment row on line 3 is skipped (lineNum-- happens),
+	// the location on line 4 is processed successfully.
+	assert.Equal(t, 1, result.LocationCount)
+	assert.Empty(t, result.InvalidEntries)
+}
+
+func TestLoadCSV_NestedLocation(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	// Parent location, then child location with home set to parent name.
+	abs := writeTestCSV(t, "type,name,home\nL,Garage,\nL,Shelf,Garage\n")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 2, result.LocationCount)
+	assert.Equal(t, 0, result.ItemCount)
+	assert.Empty(t, result.InvalidEntries)
+}
+
+func TestLoadCSV_ItemMissingHome(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	// Item row with empty home field.
+	abs := writeTestCSV(t, "type,name,home\nI,Hammer,\n")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 0, result.ItemCount)
+	require.Len(t, result.InvalidEntries, 1)
+
+	inv := result.InvalidEntries[0]
+	assert.Equal(t, 2, inv.Line)
+	assert.Equal(t, "Hammer", inv.Entry)
+	assert.Contains(t, inv.Error, "missing home")
+}
+
+func TestLoadCSV_MultipleLocationsAndItems(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	// Multiple locations and items with various nesting.
+	csv := `type,name,home
+L,House,
+L,Garage,House
+L,Workshop,House
+I,Hammer,Workshop
+I,Wrench,Workshop
+I,Flashlight,Garage
+`
+	abs := writeTestCSV(t, csv)
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 3, result.LocationCount)
+	assert.Equal(t, 3, result.ItemCount)
+	assert.Empty(t, result.InvalidEntries)
+}
+
+func TestLoadCSV_CaseSensitiveType(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	// Type is case-insensitive (uppercase conversion happens).
+	abs := writeTestCSV(t, "type,name,home\nl,Garage,\ni,Hammer,Garage\n")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 1, result.LocationCount)
+	assert.Equal(t, 1, result.ItemCount)
+	assert.Empty(t, result.InvalidEntries)
+}
+
+func TestLoadCSV_FlexibleColumnOrder(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	// Columns in different order.
+	abs := writeTestCSV(t, "name,home,type\nGarage,,L\nHammer,Garage,I\n")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 1, result.LocationCount)
+	assert.Equal(t, 1, result.ItemCount)
+	assert.Empty(t, result.InvalidEntries)
+}
+
+func TestLoadCSV_DuplicateLocationName(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	// Try to add the same location twice.
+	abs := writeTestCSV(t, "type,name,home\nL,Garage,\nL,Garage,\n")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// First location succeeds, second fails due to duplicate.
+	assert.Equal(t, 1, result.LocationCount)
+	require.Len(t, result.InvalidEntries, 1)
+
+	inv := result.InvalidEntries[0]
+	assert.Equal(t, 3, inv.Line)
+	assert.Equal(t, "Garage", inv.Entry)
+	assert.NotEmpty(t, inv.Error)
+}
+
+func TestLoadCSV_WhitespaceHandling(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	// Whitespace around field values should be trimmed.
+	abs := writeTestCSV(t, "type,name,home\n L , Garage , \n I , Hammer , Garage \n")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 1, result.LocationCount)
+	assert.Equal(t, 1, result.ItemCount)
+	assert.Empty(t, result.InvalidEntries)
+}
+
+func TestLoadCSV_HeaderColumnCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	// Header column names should be case-insensitive.
+	abs := writeTestCSV(t, "TYPE,NAME,HOME\nL,Garage,\nI,Hammer,Garage\n")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 1, result.LocationCount)
+	assert.Equal(t, 1, result.ItemCount)
+	assert.Empty(t, result.InvalidEntries)
+}
+
+func TestLoadCSV_MissingOptionalHomeForLocation(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	// Home is optional for locations (can be completely missing from CSV).
+	abs := writeTestCSV(t, "type,name\nL,Garage\n")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 1, result.LocationCount)
+	assert.Empty(t, result.InvalidEntries)
+}
+
+func TestLoadCSV_MalformedCSVRow(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	// An unterminated quoted field causes encoding/csv to return a parse error.
+	// The row should be recorded as an InvalidEntry and parsing should continue.
+	abs := writeTestCSV(t, "type,name,home\nL,\"unterminated")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 0, result.LocationCount)
+	require.Len(t, result.InvalidEntries, 1)
+	assert.Contains(t, result.InvalidEntries[0].Error, "malformed CSV row")
+}
+
+func TestLoadCSV_MultipleInvalidRows(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	// Multiple invalid rows should all be recorded.
+	csv := `type,name,home
+X,BadType,
+L,,
+I,NoHome,
+L,Ga:rage,
+L,ValidLocation,
+`
+	abs := writeTestCSV(t, csv)
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 1, result.LocationCount)
+	assert.Equal(t, 0, result.ItemCount)
+	require.Len(t, result.InvalidEntries, 4)
+
+	// Verify line numbers are correct.
+	expectedLines := []int{2, 3, 4, 5}
+	for i, inv := range result.InvalidEntries {
+		assert.Equal(t, expectedLines[i], inv.Line, "invalid entry %d should be on line %d", i, expectedLines[i])
+	}
+}
+
+func TestLoadCSV_EmptyCSVHeaderOnly(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	// CSV with only a header and no data rows.
+	abs := writeTestCSV(t, "type,name,home")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 0, result.LocationCount)
+	assert.Equal(t, 0, result.ItemCount)
+	assert.Empty(t, result.InvalidEntries)
+}
+
+func TestLoadCSV_PathPreservedInResult(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	abs := writeTestCSV(t, "type,name,home\nL,Garage,\n")
+	displayPath := "my_data/import.csv"
+
+	result, err := loadCSV(context.Background(), db, abs, displayPath)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, displayPath, result.Path)
+}
+
+func TestLoadCSV_ExtraColumnsIgnored(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	// Extra columns beyond type, name, home should be ignored.
+	abs := writeTestCSV(t, "type,name,home,extra,more\nL,Garage,,data,stuff\nI,Hammer,Garage,unused,columns\n")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 1, result.LocationCount)
+	assert.Equal(t, 1, result.ItemCount)
+	assert.Empty(t, result.InvalidEntries)
+}
+
+func TestLoadCSV_ContextPropagation(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	abs := writeTestCSV(t, "type,name,home\nL,Garage,\n")
+
+	// Use a context that could be cancelled.
+	ctx := t.Context()
+
+	result, err := loadCSV(ctx, db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 1, result.LocationCount)
+}
+
+func TestLoadCSV_AllLocationNamesInvalid(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	// All locations have invalid names (e.g., colons).
+	csv := `type,name,home
+L,Ga:rage,
+L,Work:shop,
+I,Hammer,Garage
+`
+	abs := writeTestCSV(t, csv)
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 0, result.LocationCount)
+	assert.Equal(t, 0, result.ItemCount)
+	require.Len(t, result.InvalidEntries, 3)
+}
+
+func TestLoadCSV_ItemNameWithinValidCharacters(t *testing.T) {
+	t.Parallel()
+	db := newTestLoadDB(t)
+	// Names with hyphens, underscores, numbers should be valid.
+	abs := writeTestCSV(t, "type,name,home\nL,Garage-1,\nI,Hammer_10mm,Garage-1\nI,Tool-123,Garage-1\n")
+
+	result, err := loadCSV(context.Background(), db, abs, "test.csv")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 1, result.LocationCount)
+	assert.Equal(t, 2, result.ItemCount)
+	assert.Empty(t, result.InvalidEntries)
+}


### PR DESCRIPTION
This pull request introduces a new bulk import feature to the CLI inventory tracker, allowing users to add locations and items from CSV files via a new `load` command. The implementation includes command registration, user documentation, CSV parsing and validation logic, and tests. It also updates code patterns and documentation to reflect the new command structure.

**Major features and changes:**

### Bulk Import Feature

* Adds a new `load` command (`cmd/load/load.go`) that enables users to import locations and items in bulk from CSV files. The command validates input files, summarizes results, and reports invalid entries without halting the import. [[1]](diffhunk://#diff-e918dd1ae4ef753d7c1dcef630b022f7bc1264e2a75a19f0a1765345a70f3e57R1-R76) [[2]](diffhunk://#diff-23f5d17c78cb7b773d9c464e211bebccfac2a9f0ecb6f045901990c330413b1aR1-R210)
* Implements CSV parsing and validation logic in `internal/cli/load.go`, including error reporting for invalid rows, flexible column handling, and enforcement of correct row ordering (locations before items).

### Command Registration and Testing

* Registers the new `load` command in the CLI root command (`cmd/root.go`) and provides basic unit tests for command construction and error cases (`cmd/load/load_test.go`). [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR19) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR73) [[3]](diffhunk://#diff-65fe236eecba5f7873bc2c0ee05f2fa0bd16e4dd9c50eca3ce95004ae127c7b1R1-R47)

### Codebase and Documentation Updates

* Updates internal DB interface patterns for testability and consistency (`internal/cli/add.go`).

These changes collectively provide a robust and user-friendly bulk import workflow, improve code maintainability, and enhance project documentation.