### PR TITLE
Implement export command

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -50,7 +50,8 @@
       "mcp__plugin_claude-code-home-manager_serena__list_memories",
       "mcp__plugin_claude-code-home-manager_serena__write_memory",
       "mcp__plugin_claude-code-home-manager_serena__replace_symbol_body",
-      "mcp__plugin_github_github__issue_read"
+      "mcp__plugin_github_github__issue_read",
+      "mcp__plugin_github_github__sub_issue_write"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/.serena/memories/conventions.md
+++ b/.serena/memories/conventions.md
@@ -1,34 +1,45 @@
 # Conventions
 
-## Command pattern
-- Each `cmd/xxx/` exposes `NewXxxCmd(db xxxDB)` (test injection) + `NewDefaultXxxCmd()` (prod wiring via `cli.OpenDatabase`)
-- Per-command interface in `cmd/xxx/db.go`; `//go:generate mockery` directive there
-- Never pass `*store.Store` or `*app.App` directly — always via local interface
-- `cmd/serve/` is shell only — no net/http, html/template, //go:embed there; all lives in `internal/web`
+## Command constructor pattern (every cmd/xxx package)
 
-## Error handling
-- Wrap: `fmt.Errorf("context: %w", err)`
-- DB ops via `ExecInTransaction` + `WithRetry`
-- No type assertions / `any` casts — typed interfaces only
+- `cmd/xxx/db.go` — `xxxApp` interface (minimal methods only) + `//go:generate mockery`
+- `cmd/xxx/xxx.go` — `NewXxxCmd(app xxxApp)` (testable), `NewDefaultXxxCmd()` (prod wiring via `cli.OpenDatabase`), `buildXxxCmd()` (cobra.Command shell), `runXxx()` (logic)
+- Registered in `cmd/root.go` via `NewDefaultXxxCmd()`
+- Never pass `*database.DB` directly to run function
 
-## Testing
-- `testify/assert` for non-fatal, `testify/require` for preconditions
-- No mocking the DB in integration tests (burned by mock/prod divergence before)
+## cmd/history as canonical template
 
-## Ordering invariant
-- Every `ORDER BY` that could tie MUST include `event_id ASC` as tiebreaker
+```go
+// db.go
+type historyApp interface {
+    GetHistory(ctx context.Context, req app.GetHistoryRequest) ([]app.HistoryResult, error)
+}
 
-## UI conventions
-- Silence is success; verbose output with `-v`/`--verbose` only
-- `--json` on all commands
-- All styles via `internal/styles` singleton; no inline `lipgloss.NewStyle()` in rendering
+// history.go
+func NewDefaultHistoryCmd() *cobra.Command { /* opens DB, calls runHistory */ }
+func NewHistoryCmd(a historyApp) *cobra.Command { /* wires runE, used in tests */ }
+func buildHistoryCmd() *cobra.Command { /* pure cobra.Command definition */ }
+func runHistory(cmd *cobra.Command, args []string, a historyApp) error { /* logic */ }
+```
+
+## web package isolation
+
+`cmd/serve/` is a thin shell only — no `net/http`, `html/template`, `//go:embed`. All server logic in `internal/web`.
+
+## Styles
+
+All styles: private fields on `Styles` struct in `internal/styles/styles.go`, access via public accessors on singleton. Never inline `lipgloss.NewStyle()` in rendering.
+
+## Error wrapping
+
+`fmt.Errorf("context: %w", err)`
+
+## DB operations
+
+All via `ExecInTransaction` + `WithRetry` helpers.
 
 ## Timestamps
-- RFC3339 UTC with `Z` suffix
-- DB path must be absolute
 
-## Adding a new EventType
-1. Add to iota + line-comment string + `eventTypeByName` map in `internal/store/eventTypes.go` (note: CLAUDE.md says `internal/database` but actual path is `internal/store`)
-2. `go generate ./...` to regen `eventtype_string.go`
-3. Add case to `applyEventTx` in `internal/eventbus/bus.go`
-4. Add handler method on `Bus` in `internal/eventbus/handlers.go`
+RFC3339 with UTC `Z` suffix.
+
+## No type assertions / `any` casts — prefer typed interfaces.

--- a/.serena/memories/core.md
+++ b/.serena/memories/core.md
@@ -1,24 +1,27 @@
-# Core — wherehouse
+# Core
 
-Event-sourced CLI inventory tracker ("where did I put my 10mm socket wrench?").
+Wherehouse: personal inventory tracker CLI. Go 1.25, event-sourced SQLite backend.
 
-## Key layers
+## Source map
 
-- `cmd/*/` — Cobra commands; one per operation; inject `*App` via per-cmd interface (`addApp`, `moveApp`, …)
-- `internal/app/` — Business logic; `App` struct; exposes `CreateEntity`, `RenameEntity`, `ReparentEntity`, `RemoveEntity`, `GetEntityByPath/ID`, `ListEntities`, `GetChildren`, `ChangeStatus`, `GetHistory`, `FindEntities`
-- `internal/eventbus/` — `Bus` dispatches events, inserts them, calls `applyEventTx` → per-type handler; handles path propagation
-- `internal/store/` — SQLite `Store`; wraps `*sql.DB`; `ExecInTransaction`/`WithRetry`; entities + events CRUD
-- `internal/inventory/` — Pure domain types: `Entity`, `EntityType`, `EntityStatus`, `Event`, `EventType`, `CanonicalizeString`
-- `internal/web/` — HTMX server; `internal/web/app.go` defines its own `App` interface (superset of cmd interfaces)
-- `internal/cli/` — Shared CLI helpers: `OpenDatabase`, `OutputWriter`, actor, flags, config access
-- `internal/entitypath/` — Colon-separated path type
+- `cmd/` — cobra commands, one subdir per command
+- `internal/app/` — business logic (`App` struct, result types like `HistoryResult`, `ExportResult`)
+- `internal/store/` — SQLite persistence (`Store` struct, migrations/)
+- `internal/inventory/` — pure domain types (`EntityType`, `EntityStatus`, `Entity`, `Event`)
+- `internal/cli/` — shared CLI helpers: selectors, output, user identity
+- `internal/config/` — XDG TOML config (viper)
+- `internal/web/` — HTTP server, handlers, templates, embedded assets
+- `internal/eventbus/` — event dispatch, path propagation
+- `internal/entitypath/` — colon-separated path parsing
+- `internal/styles/` — lipgloss appStyles singleton (Wong palette, AdaptiveColor)
+- `internal/nanoid/` — 10-char alphanumeric NanoID generation
+- `cmd/root.go` — root command, registers via `NewDefaultXxxCmd()`
 
-## Critical data flow
+## Key invariants
 
-Command → `cli.OpenDatabase` → `store.Open` + `app.New(store)` → command injects `*app.App` via local interface → `app.X` → `bus.Dispatch` → `applyEventTx` → handler updates `entities_current` projection in same tx
+- Events are immutable source of truth (append-only). Projections are rebuildable.
+- Every `ORDER BY` that could tie **must** include `event_id ASC` tiebreaker.
+- DB schema source of truth: `events(event_id PK, event_type, timestamp_utc, actor_user_id, payload JSON, note)`
+- Projection tables: `locations_current`, `items_current`, `projects_current`
 
-## Storage schema
-
-Two tables: `events` (append-only, source of truth) + `entities_current` (sole projection, rebuildable). Every `ORDER BY` that could tie must include `event_id ASC`.
-
-See `mem:tech_stack`, `mem:conventions`, `mem:suggested_commands`, `mem:task_completion`.
+See `mem:conventions` for command patterns; `mem:tech_stack` for build tools.

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,32 +1,29 @@
 # Suggested Commands
 
-## Build & test
+## Build & test (mise tasks in `.mise/tasks/`)
+
 ```
-mise run build      # go build → dist/wherehouse
-mise run test       # gotestsum, race, coverage → bin/coverage.out
-mise run lint       # golangci-lint --fix → bin/golangci-lint.html
-mise run generate   # go generate ./... (stringer)
-mise run mock       # regenerate mocks via mockery
-mise run dev        # generate + lint + test + snapshot + mock
-mise run snapshot   # goreleaser single-target snapshot
-mise run cover      # coverage HTML → bin/coverage.html
-mise run mod-tidy   # go mod tidy + gomod2nix generate
+mise run build     # go build → dist/wherehouse
+mise run test      # gotestsum, race detector, coverage
+mise run lint      # golangci-lint --fix
+mise run generate  # go generate ./... (stringer for iota enums)
+mise run mock      # regenerate mocks via mockery
+mise run dev       # generate + lint + test + snapshot + mock
+mise run snapshot  # goreleaser build (single target)
+mise run cover     # coverage HTML → bin/coverage.html
+mise run mod-tidy  # go mod tidy + gomod2nix generate
 ```
 
-## Single-package / single-test
+## Single package / test
+
 ```
-gotestsum -- -race ./internal/store/...
+gotestsum -- -race ./internal/database/...
 gotestsum -- -run TestFoo ./cmd/scry/...
 ```
 
-## VCS (jujutsu, not git)
-```
-jj log --no-graph -r 'trunk()..@'   # review branch history
-jj describe <change-id> -m "msg"    # rename a commit
-```
+## VCS (jujutsu — NOT git)
 
-## Preferred shell tools
-- `fd` over `find`
-- `rg` over `grep`
-- `sd` over `sed`
-- `jq` for JSON
+```
+jj log --no-graph -r 'trunk()..@'   # branch history
+jj describe <change-id> -m "msg"    # rename commit
+```

--- a/.serena/memories/task_completion.md
+++ b/.serena/memories/task_completion.md
@@ -1,8 +1,9 @@
-# Task Completion Checklist
+# Task Completion
 
-Run these before every commit:
-1. `mise run lint` — fix all warnings
-2. `mise run test` — all tests pass with race detector
-3. Run `/pre-commit` skill
-4. Run `/commit` skill (conventional commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`)
-5. Run `/audit-docs` after features or fixes
+Run in order before every commit:
+
+1. `mise run lint`   — golangci-lint --fix (must be clean)
+2. `mise run test`   — gotestsum with race detector (must pass)
+3. `/pre-commit` skill
+4. `/commit` skill for message (conventional commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`)
+5. `/audit-docs` after features or fixes

--- a/.serena/memories/tech_stack.md
+++ b/.serena/memories/tech_stack.md
@@ -1,17 +1,11 @@
 # Tech Stack
 
-- **Language**: Go 1.25, no CGo
-- **CLI framework**: Cobra (github.com/spf13/cobra)
-- **Config**: Viper-backed TOML, XDG-compliant (`internal/config`)
-- **DB**: SQLite (modernc.org/sqlite, no cgo); migrations in `internal/store/migrations/`
-- **ID generation**: 10-char alphanumeric NanoID (`internal/nanoid`)
-- **Build**: mise tasks (`mise run build/test/lint/generate/mock/dev/snapshot`)
-- **Test runner**: gotestsum + race detector
-- **Lint**: golangci-lint --fix
-- **Code gen**: stringer for iota enums (`go generate ./...`), mockery for mocks
-- **Release**: goreleaser (snapshot only in dev)
-- **Web UI**: HTMX templates, embedded assets in `internal/web/assets`
-- **Styling**: lipgloss + Wong palette with AdaptiveColor (colorblind safe)
-- **Fuzzy search**: Levenshtein distance (`internal/app/search.go`)
-- **Module management**: gomod2nix (`mise run mod-tidy`)
-- **VCS**: jujutsu (`jj`), not git
+- Language: Go 1.25, no CGo
+- CLI framework: cobra
+- DB: SQLite (via `internal/store`)
+- Config: viper-backed TOML (XDG)
+- Styling: lipgloss (Wong palette, `AdaptiveColor{Light, Dark}`)
+- Test: `testify/assert` (non-fatal), `testify/require` (preconditions); mocks via mockery
+- Build: mise tasks (see `mem:suggested_commands`)
+- Release: goreleaser (snapshot only via `mise run snapshot`)
+- Module: `github.com/asphaltbuffet/wherehouse`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.4.0] - 2026-05-28
+
+### Added
+
+- Add `export` command to stream the full event log to stdout as NDJSON (one JSON object per line, ordered by `event_id ASC`)
+- Add `--quiet` / `-q` flag to `export`: suppresses the zero-events warning on stderr; stdout data stream is unaffected
+- Add `--json` flag accepted as a no-op on `export` (command always emits NDJSON; flag exists for scripting consistency)
+- Add `app.ExportResult` type with all event fields; `payload` field is a nested JSON object (not base64 or a JSON string)
+- Add ADR documenting the export/import design
+
+### Changed
+
+- Remove unused `//go:generate mockery` directives from packages that no longer need generated mocks
+
 ## [0.3.0] - 2026-05-26
 
 ### Added
@@ -91,6 +105,7 @@ _First release._
 - Use NanoID instead of UUID for item identifiers (shorter, more readable) ([`4772974`](https://github.com/asphaltbuffet/wherehouse/commit/4772974))
 - Unify output styling across all commands ([`0e24808`](https://github.com/asphaltbuffet/wherehouse/commit/0e24808))
 
+[0.4.0]: https://github.com/asphaltbuffet/wherehouse/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/asphaltbuffet/wherehouse/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/asphaltbuffet/wherehouse/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/asphaltbuffet/wherehouse/compare/v0.0.0...v0.1.0

--- a/README.md
+++ b/README.md
@@ -219,7 +219,19 @@ wherehouse remove "Garage:Tool Chest:Broken Wrench"
 wherehouse remove "Garage:Old Box" --note "disposed"
 ```
 
-### 10. Web UI
+### 10. Export Event Log
+
+```bash
+# Export all events as NDJSON (one JSON object per line)
+wherehouse export
+
+# Suppress the "no events" warning when the database is empty
+wherehouse export --quiet
+```
+
+The `--json` flag is accepted silently (the command always emits NDJSON).
+
+### 11. Web UI
 
 ```bash
 # Start local web server (default: http://127.0.0.1:8080)
@@ -248,6 +260,7 @@ Entity Management:
   list                 List entities (--under, --type, --status filters)
   scry [<name>]        Search entities by name, or list all
   history <path>       Show full event timeline for an entity
+  export               Export all events as NDJSON to stdout
 
 Web UI:
   serve                Start local web server (--port, --bind)

--- a/cmd/add/db.go
+++ b/cmd/add/db.go
@@ -6,8 +6,6 @@ import (
 	"github.com/asphaltbuffet/wherehouse/internal/app"
 )
 
-//go:generate mockery
-
 type addApp interface {
 	CreateEntity(ctx context.Context, req app.CreateEntityRequest) (app.EntityResult, error)
 }

--- a/cmd/export/db.go
+++ b/cmd/export/db.go
@@ -7,8 +7,6 @@ import (
 	"github.com/asphaltbuffet/wherehouse/internal/app"
 )
 
-//go:generate mockery
-
 type exportApp interface {
 	GetAllEvents(ctx context.Context) ([]app.ExportResult, error)
 }

--- a/cmd/export/db.go
+++ b/cmd/export/db.go
@@ -1,0 +1,14 @@
+// Package export implements the export command for dumping all events as JSON.
+package export
+
+import (
+	"context"
+
+	"github.com/asphaltbuffet/wherehouse/internal/app"
+)
+
+//go:generate mockery
+
+type exportApp interface {
+	GetAllEvents(ctx context.Context) ([]app.ExportResult, error)
+}

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -1,0 +1,49 @@
+package export
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/asphaltbuffet/wherehouse/internal/cli"
+)
+
+// NewDefaultExportCmd returns the export command wired to the real database.
+func NewDefaultExportCmd() *cobra.Command {
+	cmd := buildExportCmd()
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		s, a, err := cli.OpenDatabase(cmd.Context())
+		if err != nil {
+			return fmt.Errorf("failed to open database: %w", err)
+		}
+		defer s.Close()
+		return runExport(cmd, args, a)
+	}
+	return cmd
+}
+
+// NewExportCmd returns the export command using the supplied exportApp (for testing).
+func NewExportCmd(a exportApp) *cobra.Command {
+	cmd := buildExportCmd()
+	cmd.RunE = func(cmd *cobra.Command, args []string) error { return runExport(cmd, args, a) }
+	return cmd
+}
+
+func buildExportCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "export",
+		Short: "Export all events as JSON",
+		Long: `Export all events from the event log as JSON.
+
+Examples:
+  wherehouse export`,
+	}
+}
+
+func runExport(cmd *cobra.Command, _ []string, a exportApp) error {
+	_, err := a.GetAllEvents(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("failed to export events: %w", err)
+	}
+	return nil
+}

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -1,6 +1,7 @@
 package export
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -41,9 +42,25 @@ Examples:
 }
 
 func runExport(cmd *cobra.Command, _ []string, a exportApp) error {
-	_, err := a.GetAllEvents(cmd.Context())
+	events, err := a.GetAllEvents(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("failed to export events: %w", err)
 	}
+
+	if len(events) == 0 {
+		if !cli.IsQuietMode(cmd) {
+			fmt.Fprintln(cmd.ErrOrStderr(), "warning: no events found")
+		}
+		return nil
+	}
+
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	for _, ev := range events {
+		err = enc.Encode(ev)
+		if err != nil {
+			return fmt.Errorf("encoding event %d: %w", ev.EventID, err)
+		}
+	}
+
 	return nil
 }

--- a/cmd/export/export_test.go
+++ b/cmd/export/export_test.go
@@ -3,15 +3,27 @@ package export_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	export "github.com/asphaltbuffet/wherehouse/cmd/export"
 	"github.com/asphaltbuffet/wherehouse/internal/app"
 )
+
+// newTestRoot returns a minimal root command with the same persistent flags
+// that cmd/root.go registers, so inherited-flag behaviour is realistic.
+func newTestRoot(fake *fakeExportApp) *cobra.Command {
+	root := &cobra.Command{Use: "wherehouse", SilenceUsage: true, SilenceErrors: true}
+	root.PersistentFlags().Bool("json", false, "")
+	root.PersistentFlags().CountP("quiet", "q", "")
+	root.AddCommand(export.NewExportCmd(fake))
+	return root
+}
 
 type fakeExportApp struct {
 	resp []app.ExportResult
@@ -22,13 +34,128 @@ func (f *fakeExportApp) GetAllEvents(_ context.Context) ([]app.ExportResult, err
 	return f.resp, f.err
 }
 
-func TestRunExport_RunsWithoutError(t *testing.T) {
+func TestRunExport_ZeroEvents(t *testing.T) {
 	t.Parallel()
 	fake := &fakeExportApp{}
 	cmd := export.NewExportCmd(fake)
-	cmd.SetOut(&bytes.Buffer{})
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	require.NoError(t, cmd.Execute())
+	assert.Empty(t, stdout.String())
+	assert.Contains(t, stderr.String(), "warning")
+}
+
+func TestRunExport_OneEvent_OutputsValidJSON(t *testing.T) {
+	t.Parallel()
+	entityID := "abc123"
+	fake := &fakeExportApp{
+		resp: []app.ExportResult{
+			{
+				EventID:      1,
+				EventType:    "entity.created",
+				TimestampUTC: "2026-05-28T00:00:00Z",
+				ActorUserID:  "user@example.com",
+				EntityID:     &entityID,
+				Payload:      json.RawMessage(`{"name":"Garage"}`),
+			},
+		},
+	}
+	cmd := export.NewExportCmd(fake)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
 	cmd.SetErr(&bytes.Buffer{})
 	require.NoError(t, cmd.Execute())
+
+	lines := splitLines(stdout.String())
+	require.Len(t, lines, 1)
+
+	var result app.ExportResult
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &result))
+	assert.Equal(t, int64(1), result.EventID)
+	assert.Equal(t, "entity.created", result.EventType)
+	assert.Equal(t, "2026-05-28T00:00:00Z", result.TimestampUTC)
+	assert.Equal(t, "user@example.com", result.ActorUserID)
+}
+
+func TestRunExport_MultipleEvents_OrderedByEventID(t *testing.T) {
+	t.Parallel()
+	fake := &fakeExportApp{
+		resp: []app.ExportResult{
+			{
+				EventID:      1,
+				EventType:    "entity.created",
+				TimestampUTC: "2026-05-28T00:00:00Z",
+				ActorUserID:  "u",
+				Payload:      json.RawMessage(`{}`),
+			},
+			{
+				EventID:      2,
+				EventType:    "entity.moved",
+				TimestampUTC: "2026-05-28T00:01:00Z",
+				ActorUserID:  "u",
+				Payload:      json.RawMessage(`{}`),
+			},
+			{
+				EventID:      3,
+				EventType:    "entity.renamed",
+				TimestampUTC: "2026-05-28T00:02:00Z",
+				ActorUserID:  "u",
+				Payload:      json.RawMessage(`{}`),
+			},
+		},
+	}
+	cmd := export.NewExportCmd(fake)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	require.NoError(t, cmd.Execute())
+
+	lines := splitLines(stdout.String())
+	require.Len(t, lines, 3)
+
+	var prev int64
+	for _, line := range lines {
+		var result app.ExportResult
+		require.NoError(t, json.Unmarshal([]byte(line), &result))
+		assert.Greater(t, result.EventID, prev)
+		prev = result.EventID
+	}
+}
+
+func TestRunExport_PayloadRoundTrip(t *testing.T) {
+	t.Parallel()
+	fake := &fakeExportApp{
+		resp: []app.ExportResult{
+			{
+				EventID:      1,
+				EventType:    "entity.created",
+				TimestampUTC: "2026-05-28T00:00:00Z",
+				ActorUserID:  "u",
+				Payload:      json.RawMessage(`{"key":"value","num":42}`),
+			},
+		},
+	}
+	cmd := export.NewExportCmd(fake)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	require.NoError(t, cmd.Execute())
+
+	lines := splitLines(stdout.String())
+	require.Len(t, lines, 1)
+
+	// Parse the raw JSON line into a generic map to inspect the payload field type.
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &raw))
+
+	payloadRaw, ok := raw["payload"]
+	require.True(t, ok, "payload field must be present")
+
+	// payload must be a JSON object, not a string or base64
+	var payloadObj map[string]any
+	require.NoError(t, json.Unmarshal(payloadRaw, &payloadObj), "payload must unmarshal as a JSON object, not a string")
+	assert.Equal(t, "value", payloadObj["key"])
 }
 
 func TestRunExport_PropagatesError(t *testing.T) {
@@ -40,4 +167,54 @@ func TestRunExport_PropagatesError(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "db failure")
+}
+
+func TestRunExport_ZeroEvents_QuietSuppressesWarning(t *testing.T) {
+	t.Parallel()
+	fake := &fakeExportApp{}
+	root := newTestRoot(fake)
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"export", "-q"})
+	require.NoError(t, root.Execute())
+	assert.Empty(t, stdout.String())
+	assert.Empty(t, stderr.String())
+}
+
+func TestRunExport_JsonFlagIsNoOp(t *testing.T) {
+	t.Parallel()
+	fake := &fakeExportApp{
+		resp: []app.ExportResult{
+			{
+				EventID:      1,
+				EventType:    "entity.created",
+				TimestampUTC: "2026-05-28T00:00:00Z",
+				ActorUserID:  "u",
+				Payload:      json.RawMessage(`{}`),
+			},
+		},
+	}
+	root := newTestRoot(fake)
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"export", "--json"})
+	require.NoError(t, root.Execute())
+	lines := splitLines(stdout.String())
+	require.Len(t, lines, 1)
+	var result app.ExportResult
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &result))
+	assert.Equal(t, int64(1), result.EventID)
+}
+
+// splitLines returns non-empty lines from s.
+func splitLines(s string) []string {
+	var lines []string
+	for line := range bytes.SplitSeq([]byte(s), []byte("\n")) {
+		if len(bytes.TrimSpace(line)) > 0 {
+			lines = append(lines, string(line))
+		}
+	}
+	return lines
 }

--- a/cmd/export/export_test.go
+++ b/cmd/export/export_test.go
@@ -1,0 +1,43 @@
+package export_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	export "github.com/asphaltbuffet/wherehouse/cmd/export"
+	"github.com/asphaltbuffet/wherehouse/internal/app"
+)
+
+type fakeExportApp struct {
+	resp []app.ExportResult
+	err  error
+}
+
+func (f *fakeExportApp) GetAllEvents(_ context.Context) ([]app.ExportResult, error) {
+	return f.resp, f.err
+}
+
+func TestRunExport_RunsWithoutError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeExportApp{}
+	cmd := export.NewExportCmd(fake)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	require.NoError(t, cmd.Execute())
+}
+
+func TestRunExport_PropagatesError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeExportApp{err: errors.New("db failure")}
+	cmd := export.NewExportCmd(fake)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db failure")
+}

--- a/cmd/history/db.go
+++ b/cmd/history/db.go
@@ -7,8 +7,6 @@ import (
 	"github.com/asphaltbuffet/wherehouse/internal/app"
 )
 
-//go:generate mockery
-
 type historyApp interface {
 	GetHistory(ctx context.Context, req app.GetHistoryRequest) ([]app.HistoryResult, error)
 }

--- a/cmd/list/db.go
+++ b/cmd/list/db.go
@@ -6,8 +6,6 @@ import (
 	"github.com/asphaltbuffet/wherehouse/internal/app"
 )
 
-//go:generate mockery
-
 type listApp interface {
 	ListEntities(ctx context.Context) ([]app.EntityResult, error)
 }

--- a/cmd/move/db.go
+++ b/cmd/move/db.go
@@ -7,8 +7,6 @@ import (
 	"github.com/asphaltbuffet/wherehouse/internal/app"
 )
 
-//go:generate mockery
-
 type moveApp interface {
 	ReparentEntity(ctx context.Context, req app.ReparentEntityRequest) (app.EntityResult, error)
 }

--- a/cmd/remove/db.go
+++ b/cmd/remove/db.go
@@ -6,8 +6,6 @@ import (
 	"github.com/asphaltbuffet/wherehouse/internal/app"
 )
 
-//go:generate mockery
-
 type removeApp interface {
 	RemoveEntity(ctx context.Context, req app.RemoveEntityRequest) error
 }

--- a/cmd/rename/db.go
+++ b/cmd/rename/db.go
@@ -7,8 +7,6 @@ import (
 	"github.com/asphaltbuffet/wherehouse/internal/app"
 )
 
-//go:generate mockery
-
 type renameApp interface {
 	RenameEntity(ctx context.Context, req app.RenameEntityRequest) (app.EntityResult, error)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/asphaltbuffet/wherehouse/cmd/add"
 	configpkg "github.com/asphaltbuffet/wherehouse/cmd/config"
+	"github.com/asphaltbuffet/wherehouse/cmd/export"
 	"github.com/asphaltbuffet/wherehouse/cmd/history"
 	listcmd "github.com/asphaltbuffet/wherehouse/cmd/list"
 	"github.com/asphaltbuffet/wherehouse/cmd/man"
@@ -65,6 +66,7 @@ Examples:
 
 	rootCmd.AddCommand(configpkg.NewConfigCmd())
 	rootCmd.AddCommand(add.NewDefaultAddCmd())
+	rootCmd.AddCommand(export.NewDefaultExportCmd())
 	rootCmd.AddCommand(history.NewDefaultHistoryCmd())
 	rootCmd.AddCommand(listcmd.NewDefaultListCmd())
 	rootCmd.AddCommand(move.NewDefaultMoveCmd())

--- a/cmd/scry/db.go
+++ b/cmd/scry/db.go
@@ -6,8 +6,6 @@ import (
 	"github.com/asphaltbuffet/wherehouse/internal/app"
 )
 
-//go:generate mockery
-
 type scryApp interface {
 	ListEntities(ctx context.Context) ([]app.EntityResult, error)
 	FindEntities(ctx context.Context, req app.FindEntitiesRequest) ([]app.FindResult, error)

--- a/cmd/status/db.go
+++ b/cmd/status/db.go
@@ -7,8 +7,6 @@ import (
 	"github.com/asphaltbuffet/wherehouse/internal/app"
 )
 
-//go:generate mockery
-
 type statusApp interface {
 	ChangeStatus(ctx context.Context, req app.ChangeStatusRequest) error
 }

--- a/docs/adr/0003-export-format-ndjson.md
+++ b/docs/adr/0003-export-format-ndjson.md
@@ -1,0 +1,5 @@
+# Export format is NDJSON (newline-delimited JSON), not a JSON array
+
+The `export` command writes one JSON object per line to stdout, with no wrapping array.
+
+We chose this over a single JSON array because NDJSON streams naturally — consumers can process events one at a time without buffering the entire output. It composes directly with standard Unix tools: `wc -l` gives the event count, `jq` processes records individually, `head`/`tail`/`grep` work line-by-line. A JSON array requires reading the entire output before parsing begins, and is marginally larger (outer brackets, inter-element commas). The export use case (backup, migration, piping) is inherently streaming-friendly.

--- a/docs/adr/0004-import-replay-event-bus-method.md
+++ b/docs/adr/0004-import-replay-event-bus-method.md
@@ -1,0 +1,7 @@
+# Import uses a new `ReplayEvent` bus method, not `Dispatch`
+
+The `import` command restores inventory state by replaying events from an NDJSON export. It cannot use the existing `eventbus.Dispatch` method because `Dispatch` stamps `time.Now()` as `timestamp_utc`, destroying the original event timestamp from the export. Timestamps are informational (replay order is by `event_id ASC`), but losing them would make the restored event log differ from the source in a way that is confusing and unnecessary.
+
+We added a `Bus.ReplayEvent(ctx, *inventory.Event) (int64, error)` method that accepts a fully-populated event (including original `TimestampUTC`), inserts it with that timestamp, and then calls the same `applyEventTx` handler as `Dispatch` to maintain projections. The new `event_id` assigned by SQLite replaces the exported one (autoincrement surrogates are not preserved across databases).
+
+`ReplayEvent` is the only sanctioned write path for import. Direct store insertion was rejected because it would bypass projection maintenance entirely, requiring a separate rebuild pass that does not exist.

--- a/docs/adr/0005-import-skips-derived-path-changed-events.md
+++ b/docs/adr/0005-import-skips-derived-path-changed-events.md
@@ -1,0 +1,7 @@
+# Import skips `EntityPathChangedEvent` records and uses them for validation
+
+`EntityPathChangedEvent` is a derived event: `propagatePathChangesTx` generates and inserts these records automatically as a side effect of handling `EntityReparentedEvent`. The export contains both the triggering reparent event and its derived path-changed events.
+
+Replaying path-changed events via `ReplayEvent` during import would corrupt the projection: `handleEntityReparented` already regenerates them, so each descendant's path would be updated twice — once by the reparent handler and once by the explicit path-changed replay.
+
+Instead, import skips `EntityPathChangedEvent` records during replay. The bus regenerates them correctly when each `EntityReparentedEvent` is replayed. The skipped records from the export are not discarded — they are compared against the freshly-generated records (via `store.GetEventsAfter`) to validate export integrity. Count mismatches or payload mismatches are surfaced as warnings in `ImportResult.Warnings` and logged via the structured logger. This validation is non-fatal: a warning indicates possible export corruption or schema divergence but does not abort the import.

--- a/docs/adr/0006-import-replace-requires-yes-flag.md
+++ b/docs/adr/0006-import-replace-requires-yes-flag.md
@@ -1,0 +1,7 @@
+# `import --replace` requires an explicit `--yes` flag, not an interactive prompt
+
+The `--replace` flag truncates all event and projection data before replaying the import — a destructive, irreversible operation. Confirmation is required to prevent accidental data loss.
+
+We chose a `--yes` flag over an interactive TTY prompt for two reasons: (1) interactive prompts require TTY detection, which adds complexity and behaves inconsistently when import is used in scripts or pipelines; (2) `--yes` is an established convention in CLI tooling (`kubectl delete`, `gh repo delete`) that is universally understood as "I know what I'm doing."
+
+`--yes` without `--replace` is silently accepted and has no effect — rejecting it would be unnecessarily strict for users who habitually pass it.

--- a/docs/adr/0007-import-requires-monotonic-event-id-order.md
+++ b/docs/adr/0007-import-requires-monotonic-event-id-order.md
@@ -1,0 +1,7 @@
+# Import requires strictly ascending `event_id` order and errors on violation
+
+The `import` command validates that `event_id` values in the NDJSON input are strictly ascending before replaying any events. If the order is non-monotonic (e.g. two export files concatenated together, or a manually shuffled file), import exits with an error and performs no DB writes.
+
+We rejected silently sorting the input for two reasons: (1) out-of-order input almost certainly indicates user error (concatenated exports, truncated file, manual editing) — surfacing this is more honest than hiding it; (2) the path-changed validation logic relies on positional ordering — `EntityPathChangedEvent` records are expected to appear immediately after their triggering `EntityReparentedEvent` in the stream, and this assumption breaks if the stream is reordered.
+
+The error message should direct the user to re-export from the source database rather than attempting to manually sort the NDJSON, since sorting by `event_id` alone does not restore the positional relationship between reparent and path-changed records.

--- a/internal/app/export.go
+++ b/internal/app/export.go
@@ -1,0 +1,41 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// ExportResult is the app-layer representation of a single event for export.
+type ExportResult struct {
+	EventID      int64           `json:"event_id"`
+	EventType    string          `json:"event_type"`
+	TimestampUTC string          `json:"timestamp_utc"`
+	ActorUserID  string          `json:"actor_user_id"`
+	EntityID     *string         `json:"entity_id,omitempty"`
+	Payload      json.RawMessage `json:"payload"`
+	Note         *string         `json:"note,omitempty"`
+}
+
+// GetAllEvents returns all events ordered by event_id ASC.
+func (a *App) GetAllEvents(ctx context.Context) ([]ExportResult, error) {
+	events, err := a.store.GetAllEvents(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get all events: %w", err)
+	}
+
+	results := make([]ExportResult, len(events))
+	for i, ev := range events {
+		results[i] = ExportResult{
+			EventID:      ev.EventID,
+			EventType:    ev.EventType.String(),
+			TimestampUTC: ev.TimestampUTC,
+			ActorUserID:  ev.ActorUserID,
+			EntityID:     ev.EntityID,
+			Payload:      ev.Payload,
+			Note:         ev.Note,
+		}
+	}
+
+	return results, nil
+}

--- a/internal/app/export_test.go
+++ b/internal/app/export_test.go
@@ -1,0 +1,98 @@
+package app_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/asphaltbuffet/wherehouse/internal/app"
+	"github.com/asphaltbuffet/wherehouse/internal/inventory"
+)
+
+func TestGetAllEvents_TracesBullet(t *testing.T) {
+	a := openTestApp(t)
+	ctx := context.Background()
+
+	_, err := a.CreateEntity(ctx, app.CreateEntityRequest{
+		DisplayName: "Box", EntityType: inventory.EntityTypeContainer, ActorID: "alice",
+	})
+	require.NoError(t, err)
+
+	results, err := a.GetAllEvents(ctx)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	r := results[0]
+	assert.Equal(t, "entity.created", r.EventType)
+	assert.NotNil(t, r.Payload)
+	assert.Positive(t, r.EventID)
+}
+
+func TestGetAllEvents_PayloadRoundTrips(t *testing.T) {
+	a := openTestApp(t)
+	ctx := context.Background()
+
+	_, err := a.CreateEntity(ctx, app.CreateEntityRequest{
+		DisplayName: "Shelf", EntityType: inventory.EntityTypeContainer, ActorID: "bob",
+	})
+	require.NoError(t, err)
+
+	results, err := a.GetAllEvents(ctx)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	// Payload must marshal as a nested JSON object, not a base64 string.
+	out, err := json.Marshal(results[0])
+	require.NoError(t, err)
+
+	var envelope map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(out, &envelope))
+
+	// payload value must start with '{', not '"' (which would indicate base64).
+	payloadBytes := envelope["payload"]
+	require.NotEmpty(t, payloadBytes)
+	assert.Equal(t, byte('{'), payloadBytes[0], "payload should be a JSON object, not a base64 string")
+}
+
+func TestGetAllEvents_NilFieldsPreserved(t *testing.T) {
+	a := openTestApp(t)
+	ctx := context.Background()
+
+	_, err := a.CreateEntity(ctx, app.CreateEntityRequest{
+		DisplayName: "Bin", EntityType: inventory.EntityTypeContainer, ActorID: "carol",
+	})
+	require.NoError(t, err)
+
+	results, err := a.GetAllEvents(ctx)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Nil(t, results[0].Note, "Note should be nil when not set")
+	assert.NotNil(t, results[0].EntityID, "EntityID should be non-nil for entity.created events")
+}
+
+func TestGetAllEvents_OrderPreserved(t *testing.T) {
+	a := openTestApp(t)
+	ctx := context.Background()
+
+	_, err := a.CreateEntity(ctx, app.CreateEntityRequest{
+		DisplayName: "Alpha", EntityType: inventory.EntityTypeContainer, ActorID: "dave",
+	})
+	require.NoError(t, err)
+
+	_, err = a.CreateEntity(ctx, app.CreateEntityRequest{
+		DisplayName: "Beta", EntityType: inventory.EntityTypeContainer, ActorID: "dave",
+	})
+	require.NoError(t, err)
+
+	results, err := a.GetAllEvents(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(results), 2)
+
+	for i := 1; i < len(results); i++ {
+		assert.Less(t, results[i-1].EventID, results[i].EventID, "events should be ordered by event_id ASC")
+	}
+}


### PR DESCRIPTION
This pull request introduces the new `export` command, enabling users to stream the full event log as NDJSON for backup or migration, and makes several documentation and codebase improvements. The most important changes are summarized below.

---

**New Feature: Export Command**

* Adds a new `export` command to the CLI, which outputs all events as newline-delimited JSON (NDJSON), ordered by `event_id ASC`. Includes support for `--quiet` (suppresses "no events" warning) and a no-op `--json` flag for scripting consistency. The new command is fully tested. [[1]](diffhunk://#diff-8fd85140189e092f2669b0514ced9fb16e826aa55325b6fd08e31789ceaae930R1-R12) [[2]](diffhunk://#diff-ce39d5c9893fdbe876354feb12f9efe7a4b2773e83d88fff2a34b4902e3f89f3R1-R66) [[3]](diffhunk://#diff-6f8ecab7c27720bb07d1d6a19835f411ebefa633e7c6f13408fa436af9371935R1-R220) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L222-R234) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R263) [[6]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R16) [[7]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR108)

**Documentation Updates**

* Updates the `README.md` with usage instructions and reference to the new `export` command. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L222-R234) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R263)
* Adds a changelog entry for version 0.4.0, detailing the export feature and related changes. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R16) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR108)
* Refines and expands internal documentation (`.serena/memories/*.md`) for conventions, core structure, tech stack, suggested commands, and task completion—clarifying command wiring, error handling, styles, and build/test practices. [[1]](diffhunk://#diff-3b80295e432ea2b137035d1e73cbd810c6cf6f324d3b074c842735cc06e071eeL3-R45) [[2]](diffhunk://#diff-ec75abfe99e76d80b0911f30d3a4602bca5131dffec1fa48f78551f4b7231a89L1-R27) [[3]](diffhunk://#diff-476cbf69d7acf462eb53db57fb8a4ddf9c7136ae2379e5942eb9244820a67f36L3-R11) [[4]](diffhunk://#diff-d105834838542150cb6b25c87edd425e3adcbc1ae5ca67d0be790bf1e5ce49c6L3-L32) [[5]](diffhunk://#diff-1b44df6e0692bc5264d2d556f93f32fe4347e6cd097d9dbc166fae7d6210df7eL1-R9)

**Codebase Maintenance**

* Removes unused `//go:generate mockery` directives from command packages that no longer require generated mocks, cleaning up test scaffolding. [[1]](diffhunk://#diff-88123493c5e1e4a10eef88de68d85875f20b32da96046d27b61852e894953791L9-L10) [[2]](diffhunk://#diff-02fdfc04182fca9ee0c127f582d1e95681e753ec206cee31c22bbb63d97d83c1L10-L11) [[3]](diffhunk://#diff-90f3945f5be992914b924711042391a92307adb9d831578da2a9394170e35172L9-L10) [[4]](diffhunk://#diff-a01326b01d36ee990b47198dc1e198163362a22efb160d9b37365d1ae58f8dd5L10-L11)

**Configuration**

* Updates `.claude/settings.local.json` to include permissions for the new export-related MCP server method.