### PR TITLE
Add event import functionality with validation and command support

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,10 @@ Status changes may carry an optional `StatusContext` (free-text, e.g. borrower n
 
 An immutable, append-only record of something that happened. Events are the **source of truth**. The `event_id` (integer, autoincrement) defines replay order — timestamps are informational only.
 
+### Note
+
+Optional free-text annotation on an `Event`. Canonically human-typed and used infrequently — for example, a one-line reason on a corrective rename. **Not** intended to hold log output, attachments, file contents, or other large blobs. Import enforces a per-record size ceiling (16 MiB) so that garbage files (e.g. binary blobs masquerading as NDJSON) fail loudly at the parser rather than at the storage layer.
+
 ### EventType
 
 The six event types currently implemented:

--- a/cmd/import/db.go
+++ b/cmd/import/db.go
@@ -10,4 +10,5 @@ import (
 type importApp interface {
 	ImportEvents(ctx context.Context, events []app.ExportResult, opts app.ImportOptions) (app.ImportResult, error)
 	HasEvents(ctx context.Context) (bool, error)
+	ClearAllData(ctx context.Context) error
 }

--- a/cmd/import/db.go
+++ b/cmd/import/db.go
@@ -1,0 +1,13 @@
+// Package importcmd implements the import command.
+package importcmd
+
+import (
+	"context"
+
+	"github.com/asphaltbuffet/wherehouse/internal/app"
+)
+
+type importApp interface {
+	ImportEvents(ctx context.Context, events []app.ExportResult, opts app.ImportOptions) (app.ImportResult, error)
+	HasEvents(ctx context.Context) (bool, error)
+}

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -2,9 +2,11 @@ package importcmd
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -49,6 +51,7 @@ Examples:
 	cmd.Flags().StringP("file", "f", "", "path to NDJSON file (default: stdin)")
 	cmd.Flags().Bool("replace", false, "clear all existing data before import")
 	cmd.Flags().Bool("yes", false, "confirm destructive --replace operation")
+	cmd.Flags().Bool("continue", false, "continue on per-event errors, accumulating failures")
 	return cmd
 }
 
@@ -58,47 +61,30 @@ func runImport(cmd *cobra.Command, a importApp) error {
 	filePath, _ := cmd.Flags().GetString("file")
 	replace, _ := cmd.Flags().GetBool("replace")
 	yes, _ := cmd.Flags().GetBool("yes")
+	cont, _ := cmd.Flags().GetBool("continue")
 
-	var r = cmd.InOrStdin()
-	if filePath != "" {
-		f, err := os.Open(filePath)
-		if err != nil {
-			return fmt.Errorf("open %q: %w", filePath, err)
-		}
-		defer f.Close()
-		r = f
+	if err := checkReplaceFlags(ctx, a, replace, yes); err != nil {
+		return err
 	}
 
-	if replace && !yes {
-		has, err := a.HasEvents(ctx)
-		if err != nil {
-			return fmt.Errorf("check existing data: %w", err)
-		}
-		if has {
-			return errors.New("database is not empty; pass --yes to confirm replacement")
+	r, closer, err := openInput(cmd, filePath)
+	if err != nil {
+		return err
+	}
+	defer closer()
+
+	events, err := parseNDJSON(r)
+	if err != nil {
+		return err
+	}
+
+	if replace && yes {
+		if clearErr := a.ClearAllData(ctx); clearErr != nil {
+			return fmt.Errorf("clear data: %w", clearErr)
 		}
 	}
 
-	var events []app.ExportResult
-	scanner := bufio.NewScanner(r)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 {
-			continue
-		}
-		var ev app.ExportResult
-		if err := json.Unmarshal(line, &ev); err != nil {
-			return fmt.Errorf("malformed JSON: %w", err)
-		}
-		events = append(events, ev)
-	}
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("read input: %w", err)
-	}
-
-	result, err := a.ImportEvents(ctx, events, app.ImportOptions{
-		Replace: replace && yes,
-	})
+	result, err := a.ImportEvents(ctx, events, app.ImportOptions{Continue: cont})
 	if err != nil {
 		return fmt.Errorf("import failed: %w", err)
 	}
@@ -109,4 +95,51 @@ func runImport(cmd *cobra.Command, a importApp) error {
 	}
 
 	return nil
+}
+
+func checkReplaceFlags(ctx context.Context, a importApp, replace, yes bool) error {
+	if replace && !yes {
+		return errors.New("--replace requires --yes to confirm the destructive operation")
+	}
+	if !replace {
+		has, err := a.HasEvents(ctx)
+		if err != nil {
+			return fmt.Errorf("check existing data: %w", err)
+		}
+		if has {
+			return errors.New("database is not empty; use --replace --yes to overwrite")
+		}
+	}
+	return nil
+}
+
+func openInput(cmd *cobra.Command, filePath string) (io.Reader, func(), error) {
+	if filePath == "" {
+		return cmd.InOrStdin(), func() {}, nil
+	}
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("open %q: %w", filePath, err)
+	}
+	return f, func() { _ = f.Close() }, nil
+}
+
+func parseNDJSON(r io.Reader) ([]app.ExportResult, error) {
+	var events []app.ExportResult
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var ev app.ExportResult
+		if err := json.Unmarshal(line, &ev); err != nil {
+			return nil, fmt.Errorf("malformed JSON: %w", err)
+		}
+		events = append(events, ev)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read input: %w", err)
+	}
+	return events, nil
 }

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -124,6 +124,15 @@ func openInput(cmd *cobra.Command, filePath string) (io.Reader, func(), error) {
 func parseNDJSON(r io.Reader) ([]app.ExportResult, error) {
 	var events []app.ExportResult
 	scanner := bufio.NewScanner(r)
+	// Per-line cap: 16 MiB. The default 64 KiB is too tight — a single Event
+	// with a long human-typed Note can exceed it. 16 MiB is 4-5 orders of
+	// magnitude above realistic events while still failing loudly on garbage
+	// files (binary blobs masquerading as NDJSON). See CONTEXT.md "Note".
+	const (
+		initialBuf = 64 << 10 // 64 KiB — Scanner default; grows on demand up to maxLine.
+		maxLine    = 16 << 20 // 16 MiB.
+	)
+	scanner.Buffer(make([]byte, initialBuf), maxLine)
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if len(line) == 0 {

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -1,0 +1,112 @@
+package importcmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/asphaltbuffet/wherehouse/internal/app"
+	"github.com/asphaltbuffet/wherehouse/internal/cli"
+)
+
+// NewDefaultImportCmd returns the import command wired to the real database.
+func NewDefaultImportCmd() *cobra.Command {
+	cmd := buildImportCmd()
+	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
+		s, a, err := cli.OpenDatabase(cmd.Context())
+		if err != nil {
+			return fmt.Errorf("failed to open database: %w", err)
+		}
+		defer s.Close()
+		return runImport(cmd, a)
+	}
+	return cmd
+}
+
+// NewImportCmd returns the import command using the supplied importApp (for testing).
+func NewImportCmd(a importApp) *cobra.Command {
+	cmd := buildImportCmd()
+	cmd.RunE = func(cmd *cobra.Command, _ []string) error { return runImport(cmd, a) }
+	return cmd
+}
+
+func buildImportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "import",
+		Short: "Import events from an NDJSON file",
+		Long: `Import events from an NDJSON export file into the database.
+
+Reads from stdin by default; use --file to read from a named file.
+
+Examples:
+  wherehouse import --file backup.ndjson
+  cat backup.ndjson | wherehouse import`,
+	}
+	cmd.Flags().StringP("file", "f", "", "path to NDJSON file (default: stdin)")
+	cmd.Flags().Bool("replace", false, "clear all existing data before import")
+	cmd.Flags().Bool("yes", false, "confirm destructive --replace operation")
+	return cmd
+}
+
+func runImport(cmd *cobra.Command, a importApp) error {
+	ctx := cmd.Context()
+
+	filePath, _ := cmd.Flags().GetString("file")
+	replace, _ := cmd.Flags().GetBool("replace")
+	yes, _ := cmd.Flags().GetBool("yes")
+
+	var r = cmd.InOrStdin()
+	if filePath != "" {
+		f, err := os.Open(filePath)
+		if err != nil {
+			return fmt.Errorf("open %q: %w", filePath, err)
+		}
+		defer f.Close()
+		r = f
+	}
+
+	if replace && !yes {
+		has, err := a.HasEvents(ctx)
+		if err != nil {
+			return fmt.Errorf("check existing data: %w", err)
+		}
+		if has {
+			return errors.New("database is not empty; pass --yes to confirm replacement")
+		}
+	}
+
+	var events []app.ExportResult
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var ev app.ExportResult
+		if err := json.Unmarshal(line, &ev); err != nil {
+			return fmt.Errorf("malformed JSON: %w", err)
+		}
+		events = append(events, ev)
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("read input: %w", err)
+	}
+
+	result, err := a.ImportEvents(ctx, events, app.ImportOptions{
+		Replace: replace && yes,
+	})
+	if err != nil {
+		return fmt.Errorf("import failed: %w", err)
+	}
+
+	if !cli.IsQuietMode(cmd) {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Replayed: %d, Failed: %d, Warnings: %d\n",
+			result.Replayed, result.Failed, result.Warnings)
+	}
+
+	return nil
+}

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -78,13 +78,10 @@ func runImport(cmd *cobra.Command, a importApp) error {
 		return err
 	}
 
-	if replace && yes {
-		if clearErr := a.ClearAllData(ctx); clearErr != nil {
-			return fmt.Errorf("clear data: %w", clearErr)
-		}
-	}
-
-	result, err := a.ImportEvents(ctx, events, app.ImportOptions{Continue: cont})
+	result, err := a.ImportEvents(ctx, events, app.ImportOptions{
+		Continue: cont,
+		Replace:  replace && yes,
+	})
 	if err != nil {
 		return fmt.Errorf("import failed: %w", err)
 	}

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -87,8 +87,12 @@ func runImport(cmd *cobra.Command, a importApp) error {
 	}
 
 	if !cli.IsQuietMode(cmd) {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Replayed: %d, Failed: %d, Warnings: %d\n",
-			result.Replayed, result.Failed, result.Warnings)
+		out := cmd.ErrOrStderr()
+		fmt.Fprintf(out, "Replayed: %d, Failed: %d, Warnings: %d\n",
+			result.Replayed, result.Failed, result.WarningCount)
+		for _, w := range result.Warnings {
+			fmt.Fprintf(out, "  warning: %s\n", w)
+		}
 	}
 
 	return nil

--- a/cmd/import/import_test.go
+++ b/cmd/import/import_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -173,6 +174,31 @@ func TestRunImport_QuietFlag_SuppressesSummary(t *testing.T) {
 
 	require.NoError(t, root.Execute())
 	assert.Empty(t, stderr.String(), "summary should be suppressed with --quiet")
+}
+
+func TestRunImport_LongLine_ParsesWithoutScannerOverflow(t *testing.T) {
+	t.Parallel()
+	fake := &fakeImportApp{importResult: app.ImportResult{Replayed: 1}}
+	cmd := importcmd.NewImportCmd(fake)
+
+	// 256 KiB note — comfortably above bufio.Scanner's default 64 KiB cap.
+	bigNote := strings.Repeat("x", 256*1024)
+	input := makeNDJSON([]app.ExportResult{
+		{
+			EventID:      1,
+			EventType:    "entity.created",
+			TimestampUTC: "2020-01-01T00:00:00Z",
+			ActorUserID:  "alice",
+			Payload:      json.RawMessage(`{}`),
+			Note:         &bigNote,
+		},
+	})
+	cmd.SetIn(bytes.NewBufferString(input))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	require.NoError(t, cmd.Execute())
+	assert.True(t, fake.importCalled, "long-line input must parse and reach ImportEvents")
 }
 
 func TestRunImport_NonEmptyDB_NoReplace_ReturnsError(t *testing.T) {

--- a/cmd/import/import_test.go
+++ b/cmd/import/import_test.go
@@ -230,9 +230,12 @@ func TestRunImport_ReplaceAndYes_ClearsBeforeImport(t *testing.T) {
 	root.SetArgs([]string{"import", "--replace", "--yes"})
 
 	require.NoError(t, root.Execute())
-	assert.True(t, fake.clearCalled, "ClearAllData must be called when --replace --yes")
 	assert.True(t, fake.importCalled)
-	require.Equal(t, []string{"clear", "import"}, fake.callOrder, "ClearAllData must precede ImportEvents")
+	assert.True(
+		t,
+		fake.importOpts.Replace,
+		"--replace --yes must pass Replace=true to ImportEvents; app layer owns the clear",
+	)
 }
 
 func TestRunImport_YesWithoutReplace_AcceptedSilently(t *testing.T) {

--- a/cmd/import/import_test.go
+++ b/cmd/import/import_test.go
@@ -31,18 +31,29 @@ type fakeImportApp struct {
 	importResult app.ImportResult
 	importErr    error
 	importCalled bool
+	importOpts   app.ImportOptions
+	clearCalled  bool
+	callOrder    []string
 }
 
 func (f *fakeImportApp) HasEvents(_ context.Context) (bool, error) {
 	return f.hasEvents, f.hasEventsErr
 }
 
+func (f *fakeImportApp) ClearAllData(_ context.Context) error {
+	f.clearCalled = true
+	f.callOrder = append(f.callOrder, "clear")
+	return nil
+}
+
 func (f *fakeImportApp) ImportEvents(
 	_ context.Context,
 	_ []app.ExportResult,
-	_ app.ImportOptions,
+	opts app.ImportOptions,
 ) (app.ImportResult, error) {
 	f.importCalled = true
+	f.importOpts = opts
+	f.callOrder = append(f.callOrder, "import")
 	return f.importResult, f.importErr
 }
 
@@ -162,4 +173,104 @@ func TestRunImport_QuietFlag_SuppressesSummary(t *testing.T) {
 
 	require.NoError(t, root.Execute())
 	assert.Empty(t, stderr.String(), "summary should be suppressed with --quiet")
+}
+
+func TestRunImport_NonEmptyDB_NoReplace_ReturnsError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeImportApp{hasEvents: true}
+	cmd := importcmd.NewImportCmd(fake)
+	cmd.SetIn(bytes.NewBufferString(makeNDJSON([]app.ExportResult{
+		{
+			EventID:      1,
+			EventType:    "entity.created",
+			TimestampUTC: "2020-01-01T00:00:00Z",
+			ActorUserID:  "alice",
+			Payload:      json.RawMessage(`{}`),
+		},
+	})))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.False(t, fake.importCalled, "ImportEvents must not be called when DB is non-empty and --replace not set")
+}
+
+func TestRunImport_ReplaceWithoutYes_ReturnsError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeImportApp{hasEvents: true}
+	root := newTestRoot(fake)
+	root.SetIn(bytes.NewBufferString(""))
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"import", "--replace"})
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.False(t, fake.clearCalled, "ClearAllData must not be called without --yes")
+	assert.False(t, fake.importCalled)
+}
+
+func TestRunImport_ReplaceAndYes_ClearsBeforeImport(t *testing.T) {
+	t.Parallel()
+	fake := &fakeImportApp{hasEvents: true}
+	root := newTestRoot(fake)
+	input := makeNDJSON([]app.ExportResult{
+		{
+			EventID:      1,
+			EventType:    "entity.created",
+			TimestampUTC: "2020-01-01T00:00:00Z",
+			ActorUserID:  "alice",
+			Payload:      json.RawMessage(`{}`),
+		},
+	})
+	root.SetIn(bytes.NewBufferString(input))
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"import", "--replace", "--yes"})
+
+	require.NoError(t, root.Execute())
+	assert.True(t, fake.clearCalled, "ClearAllData must be called when --replace --yes")
+	assert.True(t, fake.importCalled)
+	require.Equal(t, []string{"clear", "import"}, fake.callOrder, "ClearAllData must precede ImportEvents")
+}
+
+func TestRunImport_YesWithoutReplace_AcceptedSilently(t *testing.T) {
+	t.Parallel()
+	fake := &fakeImportApp{hasEvents: false}
+	root := newTestRoot(fake)
+	root.SetIn(bytes.NewBufferString(""))
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"import", "--yes"})
+
+	require.NoError(t, root.Execute())
+	assert.False(t, fake.clearCalled)
+}
+
+func TestRunImport_ContinueFlag_ExitsZeroAndShowsFailedCount(t *testing.T) {
+	t.Parallel()
+	fake := &fakeImportApp{
+		hasEvents:    false,
+		importResult: app.ImportResult{Replayed: 1, Failed: 2, Warnings: 0},
+	}
+	root := newTestRoot(fake)
+	input := makeNDJSON([]app.ExportResult{
+		{
+			EventID:      1,
+			EventType:    "entity.created",
+			TimestampUTC: "2020-01-01T00:00:00Z",
+			ActorUserID:  "alice",
+			Payload:      json.RawMessage(`{}`),
+		},
+	})
+	root.SetIn(bytes.NewBufferString(input))
+	var stderr bytes.Buffer
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"import", "--continue"})
+
+	require.NoError(t, root.Execute(), "exit must be 0 with --continue even on partial failure")
+	assert.True(t, fake.importOpts.Continue, "--continue must be passed through to ImportOptions")
+	assert.Contains(t, stderr.String(), "Failed: 2")
 }

--- a/cmd/import/import_test.go
+++ b/cmd/import/import_test.go
@@ -1,0 +1,165 @@
+package importcmd_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	importcmd "github.com/asphaltbuffet/wherehouse/cmd/import"
+	"github.com/asphaltbuffet/wherehouse/internal/app"
+)
+
+// newTestRoot wraps the import command under a minimal root that carries the
+// same persistent flags as cmd/root.go so inherited-flag behaviour is realistic.
+func newTestRoot(fake *fakeImportApp) *cobra.Command {
+	root := &cobra.Command{Use: "wherehouse", SilenceUsage: true, SilenceErrors: true}
+	root.PersistentFlags().Bool("json", false, "")
+	root.PersistentFlags().CountP("quiet", "q", "")
+	root.AddCommand(importcmd.NewImportCmd(fake))
+	return root
+}
+
+type fakeImportApp struct {
+	hasEvents    bool
+	hasEventsErr error
+	importResult app.ImportResult
+	importErr    error
+	importCalled bool
+}
+
+func (f *fakeImportApp) HasEvents(_ context.Context) (bool, error) {
+	return f.hasEvents, f.hasEventsErr
+}
+
+func (f *fakeImportApp) ImportEvents(
+	_ context.Context,
+	_ []app.ExportResult,
+	_ app.ImportOptions,
+) (app.ImportResult, error) {
+	f.importCalled = true
+	return f.importResult, f.importErr
+}
+
+func makeNDJSON(events []app.ExportResult) string {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	for _, ev := range events {
+		_ = enc.Encode(ev)
+	}
+	return buf.String()
+}
+
+// --- slice 1: valid NDJSON → ImportEvents called, summary on stderr ---
+
+func TestRunImport_ValidInput_CallsImportEventsAndPrintsSummary(t *testing.T) {
+	t.Parallel()
+	fake := &fakeImportApp{
+		importResult: app.ImportResult{Replayed: 2, Failed: 0, Warnings: 0},
+	}
+	cmd := importcmd.NewImportCmd(fake)
+	input := makeNDJSON([]app.ExportResult{
+		{
+			EventID:      1,
+			EventType:    "entity.created",
+			TimestampUTC: "2020-01-01T00:00:00Z",
+			ActorUserID:  "alice",
+			Payload:      json.RawMessage(`{}`),
+		},
+		{
+			EventID:      2,
+			EventType:    "entity.renamed",
+			TimestampUTC: "2020-01-02T00:00:00Z",
+			ActorUserID:  "alice",
+			Payload:      json.RawMessage(`{}`),
+		},
+	})
+	cmd.SetIn(bytes.NewBufferString(input))
+	var stderr bytes.Buffer
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&stderr)
+
+	require.NoError(t, cmd.Execute())
+	assert.True(t, fake.importCalled, "ImportEvents should have been called")
+	assert.Contains(t, stderr.String(), "Replayed: 2")
+	assert.Contains(t, stderr.String(), "Failed: 0")
+	assert.Contains(t, stderr.String(), "Warnings: 0")
+}
+
+func TestRunImport_EmptyInput_PrintsZeroSummary(t *testing.T) {
+	t.Parallel()
+	fake := &fakeImportApp{}
+	cmd := importcmd.NewImportCmd(fake)
+	cmd.SetIn(bytes.NewBufferString(""))
+	var stderr bytes.Buffer
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&stderr)
+
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, stderr.String(), "Replayed: 0")
+	assert.Contains(t, stderr.String(), "Failed: 0")
+	assert.Contains(t, stderr.String(), "Warnings: 0")
+}
+
+func TestRunImport_MalformedJSON_ReturnsError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeImportApp{}
+	cmd := importcmd.NewImportCmd(fake)
+	cmd.SetIn(bytes.NewBufferString("not valid json\n"))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.False(t, fake.importCalled)
+}
+
+func TestRunImport_ImportEventsError_ReturnsError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeImportApp{importErr: errors.New("monotonic order violation")}
+	cmd := importcmd.NewImportCmd(fake)
+	input := makeNDJSON([]app.ExportResult{
+		{
+			EventID:      1,
+			EventType:    "entity.created",
+			TimestampUTC: "2020-01-01T00:00:00Z",
+			ActorUserID:  "alice",
+			Payload:      json.RawMessage(`{}`),
+		},
+	})
+	cmd.SetIn(bytes.NewBufferString(input))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "monotonic order violation")
+}
+
+func TestRunImport_QuietFlag_SuppressesSummary(t *testing.T) {
+	t.Parallel()
+	fake := &fakeImportApp{importResult: app.ImportResult{Replayed: 1}}
+	root := newTestRoot(fake)
+	input := makeNDJSON([]app.ExportResult{
+		{
+			EventID:      1,
+			EventType:    "entity.created",
+			TimestampUTC: "2020-01-01T00:00:00Z",
+			ActorUserID:  "alice",
+			Payload:      json.RawMessage(`{}`),
+		},
+	})
+	root.SetIn(bytes.NewBufferString(input))
+	var stderr bytes.Buffer
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"import", "-q"})
+
+	require.NoError(t, root.Execute())
+	assert.Empty(t, stderr.String(), "summary should be suppressed with --quiet")
+}

--- a/cmd/import/import_test.go
+++ b/cmd/import/import_test.go
@@ -72,7 +72,7 @@ func makeNDJSON(events []app.ExportResult) string {
 func TestRunImport_ValidInput_CallsImportEventsAndPrintsSummary(t *testing.T) {
 	t.Parallel()
 	fake := &fakeImportApp{
-		importResult: app.ImportResult{Replayed: 2, Failed: 0, Warnings: 0},
+		importResult: app.ImportResult{Replayed: 2, Failed: 0, WarningCount: 0},
 	}
 	cmd := importcmd.NewImportCmd(fake)
 	input := makeNDJSON([]app.ExportResult{
@@ -201,6 +201,39 @@ func TestRunImport_LongLine_ParsesWithoutScannerOverflow(t *testing.T) {
 	assert.True(t, fake.importCalled, "long-line input must parse and reach ImportEvents")
 }
 
+func TestRunImport_WarningsWithDetails_PrintsDetailLines(t *testing.T) {
+	t.Parallel()
+	fake := &fakeImportApp{
+		importResult: app.ImportResult{
+			Replayed:     1,
+			WarningCount: 2,
+			Warnings: []error{
+				errors.New("orphaned EntityPathChangedEvent at event_id 7"),
+				errors.New("path-changed count mismatch after reparent event_id 9 (expected 2, got 1)"),
+			},
+		},
+	}
+	cmd := importcmd.NewImportCmd(fake)
+	cmd.SetIn(bytes.NewBufferString(makeNDJSON([]app.ExportResult{
+		{
+			EventID:      1,
+			EventType:    "entity.created",
+			TimestampUTC: "2020-01-01T00:00:00Z",
+			ActorUserID:  "alice",
+			Payload:      json.RawMessage(`{}`),
+		},
+	})))
+	var stderr bytes.Buffer
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&stderr)
+
+	require.NoError(t, cmd.Execute())
+	out := stderr.String()
+	assert.Contains(t, out, "Warnings: 2", "summary line shows the count")
+	assert.Contains(t, out, "orphaned EntityPathChangedEvent at event_id 7", "detail line for warning #1")
+	assert.Contains(t, out, "path-changed count mismatch after reparent event_id 9", "detail line for warning #2")
+}
+
 func TestRunImport_NonEmptyDB_NoReplace_ReturnsError(t *testing.T) {
 	t.Parallel()
 	fake := &fakeImportApp{hasEvents: true}
@@ -281,7 +314,7 @@ func TestRunImport_ContinueFlag_ExitsZeroAndShowsFailedCount(t *testing.T) {
 	t.Parallel()
 	fake := &fakeImportApp{
 		hasEvents:    false,
-		importResult: app.ImportResult{Replayed: 1, Failed: 2, Warnings: 0},
+		importResult: app.ImportResult{Replayed: 1, Failed: 2, WarningCount: 0},
 	}
 	root := newTestRoot(fake)
 	input := makeNDJSON([]app.ExportResult{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	configpkg "github.com/asphaltbuffet/wherehouse/cmd/config"
 	"github.com/asphaltbuffet/wherehouse/cmd/export"
 	"github.com/asphaltbuffet/wherehouse/cmd/history"
+	importcmd "github.com/asphaltbuffet/wherehouse/cmd/import"
 	listcmd "github.com/asphaltbuffet/wherehouse/cmd/list"
 	"github.com/asphaltbuffet/wherehouse/cmd/man"
 	"github.com/asphaltbuffet/wherehouse/cmd/move"
@@ -68,6 +69,7 @@ Examples:
 	rootCmd.AddCommand(add.NewDefaultAddCmd())
 	rootCmd.AddCommand(export.NewDefaultExportCmd())
 	rootCmd.AddCommand(history.NewDefaultHistoryCmd())
+	rootCmd.AddCommand(importcmd.NewDefaultImportCmd())
 	rootCmd.AddCommand(listcmd.NewDefaultListCmd())
 	rootCmd.AddCommand(move.NewDefaultMoveCmd())
 	rootCmd.AddCommand(remove.NewDefaultRemoveCmd())

--- a/docs/adr/0004-import-replay-event-bus-method.md
+++ b/docs/adr/0004-import-replay-event-bus-method.md
@@ -5,3 +5,12 @@ The `import` command restores inventory state by replaying events from an NDJSON
 We added a `Bus.ReplayEvent(ctx, *inventory.Event) (int64, error)` method that accepts a fully-populated event (including original `TimestampUTC`), inserts it with that timestamp, and then calls the same `applyEventTx` handler as `Dispatch` to maintain projections. The new `event_id` assigned by SQLite replaces the exported one (autoincrement surrogates are not preserved across databases).
 
 `ReplayEvent` is the only sanctioned write path for import. Direct store insertion was rejected because it would bypass projection maintenance entirely, requiring a separate rebuild pass that does not exist.
+
+## Implementation note: shared writeEvent helper
+
+Both `Dispatch` and `ReplayEvent` now delegate to a private `Bus.writeEvent(ctx, *inventory.Event) (int64, error)` helper that owns the INSERT + `LastInsertId` + `applyEventTx` sequence. The public separation between `Dispatch` and `ReplayEvent` remains because the two paths differ in how they source `TimestampUTC` and `EntityID`:
+
+- `Dispatch` stamps `time.Now()` and parses `entity_id` from the payload.
+- `ReplayEvent` uses the values already on the supplied `*inventory.Event`.
+
+If a future change needs to differ further between the two paths (for example, one adds a validation step or a side effect the other shouldn't), express it as a parameter to `writeEvent` rather than re-splitting the helper into two implementations. Keeping a single canonical write path is what makes "ReplayEvent and Dispatch produce identical post-conditions" a checkable property instead of a hope.

--- a/docs/adr/0005-import-skips-derived-path-changed-events.md
+++ b/docs/adr/0005-import-skips-derived-path-changed-events.md
@@ -4,4 +4,13 @@
 
 Replaying path-changed events via `ReplayEvent` during import would corrupt the projection: `handleEntityReparented` already regenerates them, so each descendant's path would be updated twice — once by the reparent handler and once by the explicit path-changed replay.
 
-Instead, import skips `EntityPathChangedEvent` records during replay. The bus regenerates them correctly when each `EntityReparentedEvent` is replayed. The skipped records from the export are not discarded — they are compared against the freshly-generated records (via `store.GetEventsAfter`) to validate export integrity. Count mismatches or payload mismatches are surfaced as warnings in `ImportResult.Warnings` and logged via the structured logger. This validation is non-fatal: a warning indicates possible export corruption or schema divergence but does not abort the import.
+Instead, import skips `EntityPathChangedEvent` records during replay. The bus regenerates them correctly when each `EntityReparentedEvent` is replayed. The skipped records from the export are not discarded — they are compared against the freshly-generated records (via `store.GetEventsAfter`) to validate export integrity. Count mismatches or payload mismatches are surfaced as warnings on the `ImportResult` and logged via the structured logger. This validation is non-fatal: a warning indicates possible export corruption or schema divergence but does not abort the import.
+
+## Warning surface
+
+Warnings are exposed on `ImportResult` as two fields kept in lockstep:
+
+- `WarningCount int` — number of warnings detected (was previously `Warnings int`).
+- `Warnings []error` — one descriptive error per warning, in detection order. `len(Warnings) == WarningCount` as an invariant.
+
+The CLI summary prints the count on its single summary line and one indented `warning: <message>` line per entry in `Warnings`, suppressed by `-q`/`--quiet`. Splitting the count from the diagnostic surface lets the CLI render actionable detail while programmatic consumers (tests, future automation) can still treat the count as a numeric outcome.

--- a/internal/app/import.go
+++ b/internal/app/import.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/asphaltbuffet/wherehouse/internal/inventory"
@@ -61,6 +62,31 @@ func importEvents(
 				i,
 				events[i].EventID,
 				events[i-1].EventID,
+			)
+		}
+	}
+
+	// Pre-replay validation (Level 2): every record must have a known EventType
+	// and a payload that parses as a JSON object. This runs before opts.Replace
+	// so a malformed input file cannot leave the database empty after ClearAllData
+	// followed by a mid-replay failure. Per-event-type schema validation is
+	// tracked as deferred work (see follow-up issue referenced in CHANGELOG).
+	for i, rec := range events {
+		if _, err := inventory.ParseEventType(rec.EventType); err != nil {
+			return ImportResult{}, fmt.Errorf(
+				"import: validation failed at index %d (event_id %d): %w",
+				i,
+				rec.EventID,
+				err,
+			)
+		}
+		var payloadShape map[string]any
+		if err := json.Unmarshal(rec.Payload, &payloadShape); err != nil {
+			return ImportResult{}, fmt.Errorf(
+				"import: validation failed at index %d (event_id %d): payload is not a JSON object: %w",
+				i,
+				rec.EventID,
+				err,
 			)
 		}
 	}

--- a/internal/app/import.go
+++ b/internal/app/import.go
@@ -42,6 +42,11 @@ func (a *App) HasEvents(ctx context.Context) (bool, error) {
 	return a.store.HasEvents(ctx)
 }
 
+// ClearAllData removes all events and entity projections from the database.
+func (a *App) ClearAllData(ctx context.Context) error {
+	return a.store.ClearAllData(ctx)
+}
+
 func importEvents(
 	ctx context.Context,
 	bus importBus,

--- a/internal/app/import.go
+++ b/internal/app/import.go
@@ -66,9 +66,6 @@ func importEvents(
 	}
 
 	if opts.Replace {
-		if _, err := store.HasEvents(ctx); err != nil {
-			return ImportResult{}, fmt.Errorf("import: check existing data: %w", err)
-		}
 		if err := store.ClearAllData(ctx); err != nil {
 			return ImportResult{}, fmt.Errorf("import: clear data: %w", err)
 		}

--- a/internal/app/import.go
+++ b/internal/app/import.go
@@ -37,6 +37,11 @@ func (a *App) ImportEvents(ctx context.Context, events []ExportResult, opts Impo
 	return importEvents(ctx, a.bus, a.store, events, opts)
 }
 
+// HasEvents reports whether the database contains any events.
+func (a *App) HasEvents(ctx context.Context) (bool, error) {
+	return a.store.HasEvents(ctx)
+}
+
 func importEvents(
 	ctx context.Context,
 	bus importBus,

--- a/internal/app/import.go
+++ b/internal/app/import.go
@@ -1,0 +1,171 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/asphaltbuffet/wherehouse/internal/inventory"
+	"github.com/asphaltbuffet/wherehouse/internal/logging"
+)
+
+// ImportOptions controls the behaviour of ImportEvents.
+type ImportOptions struct {
+	Replace  bool // clear all data before replay (caller must have confirmed)
+	Continue bool // accumulate per-event errors instead of aborting
+}
+
+// ImportResult summarises the outcome of an import run.
+type ImportResult struct {
+	Replayed int
+	Failed   int
+	Warnings int
+	Errors   []error
+}
+
+type importBus interface {
+	ReplayEvent(ctx context.Context, ev *inventory.Event) (int64, error)
+}
+
+type importStore interface {
+	HasEvents(ctx context.Context) (bool, error)
+	ClearAllData(ctx context.Context) error
+	GetEventsAfter(ctx context.Context, afterID int64) ([]*inventory.Event, error)
+}
+
+// ImportEvents replays a slice of ExportResult records into the database.
+func (a *App) ImportEvents(ctx context.Context, events []ExportResult, opts ImportOptions) (ImportResult, error) {
+	return importEvents(ctx, a.bus, a.store, events, opts)
+}
+
+func importEvents(
+	ctx context.Context,
+	bus importBus,
+	store importStore,
+	events []ExportResult,
+	opts ImportOptions,
+) (ImportResult, error) {
+	for i := 1; i < len(events); i++ {
+		if events[i].EventID <= events[i-1].EventID {
+			return ImportResult{}, fmt.Errorf(
+				"import: event_id order is non-monotonic at index %d (id %d after %d); re-export from source",
+				i,
+				events[i].EventID,
+				events[i-1].EventID,
+			)
+		}
+	}
+
+	if opts.Replace {
+		if _, err := store.HasEvents(ctx); err != nil {
+			return ImportResult{}, fmt.Errorf("import: check existing data: %w", err)
+		}
+		if err := store.ClearAllData(ctx); err != nil {
+			return ImportResult{}, fmt.Errorf("import: clear data: %w", err)
+		}
+	}
+
+	r := &importRunner{bus: bus, store: store, log: logging.GetLogger(), opts: opts, pendingReparentID: -1}
+	for _, rec := range events {
+		if err := r.processRecord(ctx, rec); err != nil {
+			return r.result, err
+		}
+	}
+	r.flushValidation(ctx)
+	return r.result, nil
+}
+
+type importRunner struct {
+	bus               importBus
+	store             importStore
+	log               logging.Logger
+	opts              ImportOptions
+	result            ImportResult
+	pendingReparentID int64
+	pathChangedBuf    []ExportResult
+}
+
+func (r *importRunner) processRecord(ctx context.Context, rec ExportResult) error {
+	et, err := inventory.ParseEventType(rec.EventType)
+	if err != nil {
+		return r.handleError(rec.EventID, err)
+	}
+
+	if et == inventory.EntityPathChangedEvent {
+		if r.pendingReparentID < 0 {
+			r.log.Warn("import: orphaned EntityPathChangedEvent (no preceding reparent)")
+			r.result.Warnings++
+		} else {
+			r.pathChangedBuf = append(r.pathChangedBuf, rec)
+		}
+		return nil
+	}
+
+	r.flushValidation(ctx)
+
+	ev := &inventory.Event{
+		EventType:    et,
+		TimestampUTC: rec.TimestampUTC,
+		ActorUserID:  rec.ActorUserID,
+		Payload:      rec.Payload,
+		Note:         rec.Note,
+		EntityID:     rec.EntityID,
+	}
+
+	newID, replayErr := r.bus.ReplayEvent(ctx, ev)
+	if replayErr != nil {
+		return r.handleError(rec.EventID, replayErr)
+	}
+	r.result.Replayed++
+
+	if et == inventory.EntityReparentedEvent {
+		r.pendingReparentID = newID
+	}
+	return nil
+}
+
+func (r *importRunner) handleError(eventID int64, err error) error {
+	wrapped := fmt.Errorf("event id %d: %w", eventID, err)
+	if r.opts.Continue {
+		r.result.Failed++
+		r.result.Errors = append(r.result.Errors, wrapped)
+		return nil
+	}
+	return wrapped
+}
+
+func (r *importRunner) flushValidation(ctx context.Context) {
+	if r.pendingReparentID < 0 {
+		return
+	}
+	generated, err := r.store.GetEventsAfter(ctx, r.pendingReparentID)
+	if err != nil {
+		r.log.Warn("import: could not retrieve generated path-changed events", "error", err)
+		r.result.Warnings++
+		r.pendingReparentID = -1
+		r.pathChangedBuf = nil
+		return
+	}
+	var genPC []*inventory.Event
+	for _, ev := range generated {
+		if ev.EventType == inventory.EntityPathChangedEvent {
+			genPC = append(genPC, ev)
+		} else {
+			break
+		}
+	}
+	if len(genPC) != len(r.pathChangedBuf) {
+		r.log.Warn("import: path-changed count mismatch after reparent",
+			"expected", len(r.pathChangedBuf), "got", len(genPC))
+		r.result.Warnings++
+	} else {
+		for i, buf := range r.pathChangedBuf {
+			if string(genPC[i].Payload) != string(buf.Payload) {
+				r.log.Warn("import: path-changed payload mismatch", "index", i)
+				r.result.Warnings++
+				break
+			}
+		}
+	}
+	r.pendingReparentID = -1
+	r.pathChangedBuf = nil
+}

--- a/internal/app/import.go
+++ b/internal/app/import.go
@@ -16,11 +16,18 @@ type ImportOptions struct {
 }
 
 // ImportResult summarises the outcome of an import run.
+//
+// WarningCount is the number of non-fatal anomalies detected during replay
+// (e.g. orphaned EntityPathChangedEvent records, mismatched path-changed
+// payloads). Warnings holds one descriptive error per increment, in
+// detection order, so callers can render diagnostics rather than only a
+// count. len(Warnings) == WarningCount as an invariant.
 type ImportResult struct {
-	Replayed int
-	Failed   int
-	Warnings int
-	Errors   []error
+	Replayed     int
+	Failed       int
+	WarningCount int
+	Warnings     []error
+	Errors       []error
 }
 
 type importBus interface {
@@ -125,8 +132,9 @@ func (r *importRunner) processRecord(ctx context.Context, rec ExportResult) erro
 
 	if et == inventory.EntityPathChangedEvent {
 		if r.pendingReparentID < 0 {
-			r.log.Warn("import: orphaned EntityPathChangedEvent (no preceding reparent)")
-			r.result.Warnings++
+			orphan := fmt.Errorf("orphaned EntityPathChangedEvent at event_id %d (no preceding reparent)", rec.EventID)
+			r.log.Warn(orphan.Error())
+			r.warn(orphan)
 		} else {
 			r.pathChangedBuf = append(r.pathChangedBuf, rec)
 		}
@@ -156,6 +164,13 @@ func (r *importRunner) processRecord(ctx context.Context, rec ExportResult) erro
 	return nil
 }
 
+// warn records a non-fatal anomaly. It bumps the counter and appends a
+// descriptive error so callers see both "how many" and "which ones.".
+func (r *importRunner) warn(err error) {
+	r.result.WarningCount++
+	r.result.Warnings = append(r.result.Warnings, err)
+}
+
 func (r *importRunner) handleError(eventID int64, err error) error {
 	wrapped := fmt.Errorf("event id %d: %w", eventID, err)
 	if r.opts.Continue {
@@ -172,8 +187,13 @@ func (r *importRunner) flushValidation(ctx context.Context) {
 	}
 	generated, err := r.store.GetEventsAfter(ctx, r.pendingReparentID)
 	if err != nil {
-		r.log.Warn("import: could not retrieve generated path-changed events", "error", err)
-		r.result.Warnings++
+		wrapped := fmt.Errorf(
+			"could not retrieve generated path-changed events after reparent event_id %d: %w",
+			r.pendingReparentID,
+			err,
+		)
+		r.log.Warn(wrapped.Error())
+		r.warn(wrapped)
 		r.pendingReparentID = -1
 		r.pathChangedBuf = nil
 		return
@@ -187,14 +207,17 @@ func (r *importRunner) flushValidation(ctx context.Context) {
 		}
 	}
 	if len(genPC) != len(r.pathChangedBuf) {
-		r.log.Warn("import: path-changed count mismatch after reparent",
-			"expected", len(r.pathChangedBuf), "got", len(genPC))
-		r.result.Warnings++
+		mismatch := fmt.Errorf("path-changed count mismatch after reparent event_id %d (expected %d, got %d)",
+			r.pendingReparentID, len(r.pathChangedBuf), len(genPC))
+		r.log.Warn(mismatch.Error())
+		r.warn(mismatch)
 	} else {
 		for i, buf := range r.pathChangedBuf {
 			if string(genPC[i].Payload) != string(buf.Payload) {
-				r.log.Warn("import: path-changed payload mismatch", "index", i)
-				r.result.Warnings++
+				mismatch := fmt.Errorf("path-changed payload mismatch after reparent event_id %d at index %d",
+					r.pendingReparentID, i)
+				r.log.Warn(mismatch.Error())
+				r.warn(mismatch)
 				break
 			}
 		}

--- a/internal/app/import_test.go
+++ b/internal/app/import_test.go
@@ -1,0 +1,276 @@
+package app_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/asphaltbuffet/wherehouse/internal/app"
+	"github.com/asphaltbuffet/wherehouse/internal/inventory"
+)
+
+func createdRecord(id int64, entityID, name string) app.ExportResult {
+	payload, _ := json.Marshal(map[string]string{
+		"entity_id":    entityID,
+		"display_name": name,
+		"entity_type":  "place",
+	})
+	return app.ExportResult{
+		EventID:      id,
+		EventType:    inventory.EntityCreatedEvent.String(),
+		TimestampUTC: "2020-01-01T00:00:00Z",
+		ActorUserID:  "alice",
+		EntityID:     &entityID,
+		Payload:      payload,
+	}
+}
+
+// --- slice 1: non-monotonic event_id → error, no replay ---
+
+func TestImportEvents_NonMonotonicOrder_ReturnsError(t *testing.T) {
+	a := openTestApp(t)
+	ctx := context.Background()
+
+	events := []app.ExportResult{
+		createdRecord(1, "e1", "Garage"),
+		createdRecord(3, "e2", "Shelf"),
+		createdRecord(2, "e3", "Box"), // out of order
+	}
+
+	_, err := a.ImportEvents(ctx, events, app.ImportOptions{})
+	require.Error(t, err)
+
+	// Confirm nothing was written.
+	results, err2 := a.GetAllEvents(ctx)
+	require.NoError(t, err2)
+	assert.Empty(t, results, "no events should be replayed when order is invalid")
+}
+
+func TestImportEvents_EmptyInput_ReturnsZeroResult(t *testing.T) {
+	a := openTestApp(t)
+	ctx := context.Background()
+
+	result, err := a.ImportEvents(ctx, nil, app.ImportOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, app.ImportResult{}, result)
+}
+
+func TestImportEvents_SingleEvent_ReplayedCountIsOne(t *testing.T) {
+	a := openTestApp(t)
+	ctx := context.Background()
+
+	events := []app.ExportResult{createdRecord(1, "e1", "Garage")}
+
+	result, err := a.ImportEvents(ctx, events, app.ImportOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Replayed)
+	assert.Equal(t, 0, result.Failed)
+	assert.Equal(t, 0, result.Warnings)
+}
+
+func TestImportEvents_PathChangedEventNotCountedAsReplayed(t *testing.T) {
+	a := openTestApp(t)
+	ctx := context.Background()
+
+	entityID := "e1"
+	pcPayload, _ := json.Marshal(map[string]any{
+		"entity_id":           entityID,
+		"full_path_display":   "Garage",
+		"full_path_canonical": "garage",
+		"depth":               0,
+	})
+
+	events := []app.ExportResult{
+		createdRecord(1, entityID, "Garage"),
+		{
+			EventID:      2,
+			EventType:    inventory.EntityPathChangedEvent.String(),
+			TimestampUTC: "2020-01-01T00:00:00Z",
+			ActorUserID:  "alice",
+			EntityID:     &entityID,
+			Payload:      pcPayload,
+		},
+	}
+
+	result, err := a.ImportEvents(ctx, events, app.ImportOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Replayed, "path-changed event should not increment Replayed")
+}
+
+func TestImportEvents_NoReparentEvents_WarningsIsZero(t *testing.T) {
+	a := openTestApp(t)
+	ctx := context.Background()
+
+	events := []app.ExportResult{
+		createdRecord(1, "e1", "Shelf"),
+		createdRecord(2, "e2", "Box"),
+	}
+
+	result, err := a.ImportEvents(ctx, events, app.ImportOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Warnings)
+}
+
+func TestImportEvents_OrphanedPathChanged_WarningIsOne(t *testing.T) {
+	a := openTestApp(t)
+	ctx := context.Background()
+
+	entityID := "e1"
+	pcPayload, _ := json.Marshal(map[string]any{
+		"entity_id":           entityID,
+		"full_path_display":   "Garage",
+		"full_path_canonical": "garage",
+		"depth":               0,
+	})
+
+	// path-changed with no preceding reparent → orphan
+	events := []app.ExportResult{
+		{
+			EventID:      1,
+			EventType:    inventory.EntityPathChangedEvent.String(),
+			TimestampUTC: "2020-01-01T00:00:00Z",
+			ActorUserID:  "alice",
+			EntityID:     &entityID,
+			Payload:      pcPayload,
+		},
+		createdRecord(2, "e2", "Box"),
+	}
+
+	result, err := a.ImportEvents(ctx, events, app.ImportOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Warnings)
+}
+
+func TestImportEvents_Continue_AccumulatesFailedAndDoesNotAbort(t *testing.T) {
+	a := openTestApp(t)
+	ctx := context.Background()
+
+	events := []app.ExportResult{
+		createdRecord(1, "e1", "Garage"),
+		{
+			EventID:      2,
+			EventType:    "entity.nonexistent", // unknown type → parse error
+			TimestampUTC: "2020-01-01T00:00:00Z",
+			ActorUserID:  "alice",
+			Payload:      json.RawMessage(`{}`),
+		},
+		createdRecord(3, "e2", "Shelf"),
+	}
+
+	result, err := a.ImportEvents(ctx, events, app.ImportOptions{Continue: true})
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Replayed)
+	assert.Equal(t, 1, result.Failed)
+	assert.Len(t, result.Errors, 1)
+}
+
+// seedReparentScenario creates a 3-level hierarchy (grandparent → parent → child),
+// reparents the parent under a new grandparent, and returns the export stream.
+// The export will contain a reparent event followed by a path-changed event for the child.
+func seedReparentScenario(t *testing.T) (*app.App, []app.ExportResult) {
+	t.Helper()
+	a := openTestApp(t)
+	ctx := context.Background()
+
+	gp1, err := a.CreateEntity(
+		ctx,
+		app.CreateEntityRequest{DisplayName: "GP1", EntityType: inventory.EntityTypePlace, ActorID: "alice"},
+	)
+	require.NoError(t, err)
+
+	gp2, err := a.CreateEntity(
+		ctx,
+		app.CreateEntityRequest{DisplayName: "GP2", EntityType: inventory.EntityTypePlace, ActorID: "alice"},
+	)
+	require.NoError(t, err)
+
+	parent, err := a.CreateEntity(
+		ctx,
+		app.CreateEntityRequest{
+			DisplayName: "Parent",
+			EntityType:  inventory.EntityTypeContainer,
+			ActorID:     "alice",
+			ParentPath:  gp1.FullPathDisplay,
+		},
+	)
+	require.NoError(t, err)
+
+	_, err = a.CreateEntity(
+		ctx,
+		app.CreateEntityRequest{
+			DisplayName: "Child",
+			EntityType:  inventory.EntityTypeContainer,
+			ActorID:     "alice",
+			ParentPath:  parent.FullPathDisplay,
+		},
+	)
+	require.NoError(t, err)
+
+	_, err = a.ReparentEntity(
+		ctx,
+		app.ReparentEntityRequest{
+			EntityPath:    parent.FullPathDisplay,
+			NewParentPath: gp2.FullPathDisplay,
+			ActorID:       "alice",
+		},
+	)
+	require.NoError(t, err)
+
+	events, err := a.GetAllEvents(ctx)
+	require.NoError(t, err)
+	return a, events
+}
+
+func TestImportEvents_ReparentWithMatchingPathChanged_WarningsIsZero(t *testing.T) {
+	_, exportedEvents := seedReparentScenario(t)
+
+	dest := openTestApp(t)
+	ctx := context.Background()
+
+	result, err := dest.ImportEvents(ctx, exportedEvents, app.ImportOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Warnings, "matching path-changed records should not produce warnings")
+}
+
+func TestImportEvents_ReparentWithMismatchedPathChangedPayload_WarningIsOne(t *testing.T) {
+	_, exportedEvents := seedReparentScenario(t)
+
+	// Corrupt the path-changed payload in the export stream.
+	for i, ev := range exportedEvents {
+		if ev.EventType == inventory.EntityPathChangedEvent.String() {
+			exportedEvents[i].Payload = json.RawMessage(
+				`{"entity_id":"corrupted","full_path_display":"WRONG","full_path_canonical":"wrong","depth":0}`,
+			)
+			break
+		}
+	}
+
+	dest := openTestApp(t)
+	ctx := context.Background()
+
+	result, err := dest.ImportEvents(ctx, exportedEvents, app.ImportOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Warnings)
+}
+
+func TestImportEvents_ReparentWithTooFewPathChangedRecords_WarningIsOne(t *testing.T) {
+	_, exportedEvents := seedReparentScenario(t)
+
+	// Remove all path-changed records from the export stream.
+	filtered := exportedEvents[:0]
+	for _, ev := range exportedEvents {
+		if ev.EventType != inventory.EntityPathChangedEvent.String() {
+			filtered = append(filtered, ev)
+		}
+	}
+
+	dest := openTestApp(t)
+	ctx := context.Background()
+
+	result, err := dest.ImportEvents(ctx, filtered, app.ImportOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Warnings)
+}

--- a/internal/app/import_test.go
+++ b/internal/app/import_test.go
@@ -274,3 +274,24 @@ func TestImportEvents_ReparentWithTooFewPathChangedRecords_WarningIsOne(t *testi
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Warnings)
 }
+
+func TestImportEvents_ReplaceTrue_ClearsExistingEventsBeforeReplay(t *testing.T) {
+	a := openTestApp(t)
+	ctx := context.Background()
+
+	first, err := a.ImportEvents(ctx, []app.ExportResult{createdRecord(1, "old", "OldPlace")}, app.ImportOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, first.Replayed)
+
+	second, err := a.ImportEvents(
+		ctx,
+		[]app.ExportResult{createdRecord(2, "new", "NewPlace")},
+		app.ImportOptions{Replace: true},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, second.Replayed)
+
+	has, err := a.HasEvents(ctx)
+	require.NoError(t, err)
+	assert.True(t, has, "second import should leave its own event in place")
+}

--- a/internal/app/import_test.go
+++ b/internal/app/import_test.go
@@ -148,14 +148,24 @@ func TestImportEvents_Continue_AccumulatesFailedAndDoesNotAbort(t *testing.T) {
 	a := openTestApp(t)
 	ctx := context.Background()
 
+	// Middle event renames an entity that was never created — passes Level 2
+	// validation (known type, valid JSON object payload) but fails at replay
+	// time inside applyEventTx. --continue must accumulate this as a per-event
+	// failure rather than aborting.
+	ghostID := "ghost"
+	renamePayload, _ := json.Marshal(map[string]string{
+		"entity_id":    ghostID,
+		"display_name": "WillFail",
+	})
 	events := []app.ExportResult{
 		createdRecord(1, "e1", "Garage"),
 		{
 			EventID:      2,
-			EventType:    "entity.nonexistent", // unknown type → parse error
+			EventType:    inventory.EntityRenamedEvent.String(),
 			TimestampUTC: "2020-01-01T00:00:00Z",
 			ActorUserID:  "alice",
-			Payload:      json.RawMessage(`{}`),
+			Payload:      renamePayload,
+			EntityID:     &ghostID,
 		},
 		createdRecord(3, "e2", "Shelf"),
 	}
@@ -294,4 +304,45 @@ func TestImportEvents_ReplaceTrue_ClearsExistingEventsBeforeReplay(t *testing.T)
 	has, err := a.HasEvents(ctx)
 	require.NoError(t, err)
 	assert.True(t, has, "second import should leave its own event in place")
+}
+
+func TestImportEvents_ReplaceTrue_MalformedRecordLeavesDBUntouched(t *testing.T) {
+	a := openTestApp(t)
+	ctx := context.Background()
+
+	first, err := a.ImportEvents(ctx, []app.ExportResult{createdRecord(1, "keep", "KeepMe")}, app.ImportOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, first.Replayed)
+
+	bad := app.ExportResult{
+		EventID:      2,
+		EventType:    "entity.created",
+		TimestampUTC: "2020-01-02T00:00:00Z",
+		ActorUserID:  "alice",
+		Payload:      json.RawMessage(`{`),
+	}
+	_, err = a.ImportEvents(ctx, []app.ExportResult{bad}, app.ImportOptions{Replace: true})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "event_id 2")
+
+	has, err := a.HasEvents(ctx)
+	require.NoError(t, err)
+	assert.True(t, has, "Replace must not clear the database when pre-validation fails")
+}
+
+func TestImportEvents_UnknownEventType_RejectedBeforeReplay(t *testing.T) {
+	a := openTestApp(t)
+	ctx := context.Background()
+
+	bad := app.ExportResult{
+		EventID:      1,
+		EventType:    "entity.exploded",
+		TimestampUTC: "2020-01-01T00:00:00Z",
+		ActorUserID:  "alice",
+		Payload:      json.RawMessage(`{}`),
+	}
+	_, err := a.ImportEvents(ctx, []app.ExportResult{bad}, app.ImportOptions{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "validation failed")
+	require.Contains(t, err.Error(), "event_id 1")
 }

--- a/internal/app/import_test.go
+++ b/internal/app/import_test.go
@@ -68,7 +68,7 @@ func TestImportEvents_SingleEvent_ReplayedCountIsOne(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Replayed)
 	assert.Equal(t, 0, result.Failed)
-	assert.Equal(t, 0, result.Warnings)
+	assert.Equal(t, 0, result.WarningCount)
 }
 
 func TestImportEvents_PathChangedEventNotCountedAsReplayed(t *testing.T) {
@@ -111,7 +111,7 @@ func TestImportEvents_NoReparentEvents_WarningsIsZero(t *testing.T) {
 
 	result, err := a.ImportEvents(ctx, events, app.ImportOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, 0, result.Warnings)
+	assert.Equal(t, 0, result.WarningCount)
 }
 
 func TestImportEvents_OrphanedPathChanged_WarningIsOne(t *testing.T) {
@@ -141,7 +141,10 @@ func TestImportEvents_OrphanedPathChanged_WarningIsOne(t *testing.T) {
 
 	result, err := a.ImportEvents(ctx, events, app.ImportOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, 1, result.Warnings)
+	assert.Equal(t, 1, result.WarningCount)
+	require.Len(t, result.Warnings, 1, "len(Warnings) must equal WarningCount")
+	assert.Contains(t, result.Warnings[0].Error(), "orphaned")
+	assert.Contains(t, result.Warnings[0].Error(), "event_id 1")
 }
 
 func TestImportEvents_Continue_AccumulatesFailedAndDoesNotAbort(t *testing.T) {
@@ -242,7 +245,7 @@ func TestImportEvents_ReparentWithMatchingPathChanged_WarningsIsZero(t *testing.
 
 	result, err := dest.ImportEvents(ctx, exportedEvents, app.ImportOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, 0, result.Warnings, "matching path-changed records should not produce warnings")
+	assert.Equal(t, 0, result.WarningCount, "matching path-changed records should not produce warnings")
 }
 
 func TestImportEvents_ReparentWithMismatchedPathChangedPayload_WarningIsOne(t *testing.T) {
@@ -263,7 +266,7 @@ func TestImportEvents_ReparentWithMismatchedPathChangedPayload_WarningIsOne(t *t
 
 	result, err := dest.ImportEvents(ctx, exportedEvents, app.ImportOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, 1, result.Warnings)
+	assert.Equal(t, 1, result.WarningCount)
 }
 
 func TestImportEvents_ReparentWithTooFewPathChangedRecords_WarningIsOne(t *testing.T) {
@@ -282,7 +285,7 @@ func TestImportEvents_ReparentWithTooFewPathChangedRecords_WarningIsOne(t *testi
 
 	result, err := dest.ImportEvents(ctx, filtered, app.ImportOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, 1, result.Warnings)
+	assert.Equal(t, 1, result.WarningCount)
 }
 
 func TestImportEvents_ReplaceTrue_ClearsExistingEventsBeforeReplay(t *testing.T) {

--- a/internal/eventbus/bus.go
+++ b/internal/eventbus/bus.go
@@ -71,6 +71,55 @@ func (b *Bus) Dispatch(
 	return eventID, nil
 }
 
+// ReplayEvent inserts a fully-populated event using its original TimestampUTC.
+// EntityPathChangedEvent is a no-op: it is skipped without error and returns 0.
+// All other event types go through applyEventTx as normal.
+func (b *Bus) ReplayEvent(ctx context.Context, ev *inventory.Event) (int64, error) {
+	if ev.EventType == inventory.EntityPathChangedEvent {
+		return 0, nil
+	}
+
+	var eventID int64
+	err := b.store.ExecInTransaction(ctx, func(tx store.Tx) error {
+		const q = `
+            INSERT INTO events (event_type, timestamp_utc, actor_user_id, payload, note, entity_id)
+            VALUES (?, ?, ?, ?, ?, ?)`
+		result, err := tx.ExecContext(
+			ctx,
+			q,
+			ev.EventType,
+			ev.TimestampUTC,
+			ev.ActorUserID,
+			string(ev.Payload),
+			ev.Note,
+			ev.EntityID,
+		)
+		if err != nil {
+			return fmt.Errorf("insert event: %w", err)
+		}
+		id, err := result.LastInsertId()
+		if err != nil {
+			return fmt.Errorf("get event ID: %w", err)
+		}
+		eventID = id
+
+		inserted := &inventory.Event{
+			EventID:      eventID,
+			EventType:    ev.EventType,
+			TimestampUTC: ev.TimestampUTC,
+			ActorUserID:  ev.ActorUserID,
+			Payload:      ev.Payload,
+			Note:         ev.Note,
+			EntityID:     ev.EntityID,
+		}
+		return b.applyEventTx(ctx, tx, inserted)
+	})
+	if err != nil {
+		return 0, err
+	}
+	return eventID, nil
+}
+
 func (b *Bus) applyEventTx(ctx context.Context, tx store.Tx, ev *inventory.Event) error {
 	switch ev.EventType {
 	case inventory.EntityCreatedEvent:

--- a/internal/eventbus/bus.go
+++ b/internal/eventbus/bus.go
@@ -21,6 +21,7 @@ func New(s *store.Store) *Bus {
 }
 
 // Dispatch persists an event and applies it to projections in a single transaction.
+// The timestamp is set to [time.Now].UTC() and entity_id is parsed from the payload.
 func (b *Bus) Dispatch(
 	ctx context.Context,
 	eventType inventory.EventType,
@@ -36,64 +37,48 @@ func (b *Bus) Dispatch(
 		}
 	}
 
-	timestamp := time.Now().UTC().Format(time.RFC3339)
-
-	var eventID int64
-	err := b.store.ExecInTransaction(ctx, func(tx store.Tx) error {
-		const q = `
-            INSERT INTO events (event_type, timestamp_utc, actor_user_id, payload, note, entity_id)
-            VALUES (?, ?, ?, ?, ?, ?)`
-		result, err := tx.ExecContext(ctx, q, eventType, timestamp, actorUserID, string(payload), note, entityID)
-		if err != nil {
-			return fmt.Errorf("insert event: %w", err)
-		}
-		id, err := result.LastInsertId()
-		if err != nil {
-			return fmt.Errorf("get event ID: %w", err)
-		}
-		eventID = id
-
-		ev := &inventory.Event{
-			EventID:      eventID,
-			EventType:    eventType,
-			TimestampUTC: timestamp,
-			ActorUserID:  actorUserID,
-			Payload:      payload,
-			Note:         note,
-			EntityID:     entityID,
-		}
-
-		return b.applyEventTx(ctx, tx, ev)
-	})
-	if err != nil {
-		return 0, err
+	ev := &inventory.Event{
+		EventType:    eventType,
+		TimestampUTC: time.Now().UTC().Format(time.RFC3339),
+		ActorUserID:  actorUserID,
+		Payload:      payload,
+		Note:         note,
+		EntityID:     entityID,
 	}
-	return eventID, nil
+	return b.writeEvent(ctx, ev)
 }
 
-// ReplayEvent inserts a fully-populated event using its original TimestampUTC.
-// EntityPathChangedEvent is a no-op: it is skipped without error and returns 0.
-// All other event types go through applyEventTx as normal.
+// ReplayEvent inserts a fully-populated event using its original TimestampUTC
+// and EntityID (no payload reparse). EntityPathChangedEvent is a no-op: it is
+// skipped without error and returns 0, because EntityReparentedEvent's handler
+// regenerates path-changed events itself.
 func (b *Bus) ReplayEvent(ctx context.Context, ev *inventory.Event) (int64, error) {
 	if ev.EventType == inventory.EntityPathChangedEvent {
 		return 0, nil
 	}
+	return b.writeEvent(ctx, ev)
+}
 
+// writeEvent is the single canonical write path shared by Dispatch and
+// ReplayEvent. It inserts ev into the events table inside a transaction,
+// then runs applyEventTx in that same transaction so projection updates are
+// atomic with the event row.
+//
+// Callers populate ev's EventType, TimestampUTC, ActorUserID, Payload, Note,
+// and EntityID. EventID is assigned by SQLite and returned to the caller.
+//
+// If a future change needs to differ between Dispatch and ReplayEvent (e.g.
+// one path adds a validation step the other shouldn't), express it as a
+// parameter to writeEvent rather than re-splitting into two methods.
+func (b *Bus) writeEvent(ctx context.Context, ev *inventory.Event) (int64, error) {
 	var eventID int64
 	err := b.store.ExecInTransaction(ctx, func(tx store.Tx) error {
 		const q = `
             INSERT INTO events (event_type, timestamp_utc, actor_user_id, payload, note, entity_id)
             VALUES (?, ?, ?, ?, ?, ?)`
-		result, err := tx.ExecContext(
-			ctx,
-			q,
-			ev.EventType,
-			ev.TimestampUTC,
-			ev.ActorUserID,
-			string(ev.Payload),
-			ev.Note,
-			ev.EntityID,
-		)
+		result, err := tx.ExecContext(ctx, q,
+			ev.EventType, ev.TimestampUTC, ev.ActorUserID,
+			string(ev.Payload), ev.Note, ev.EntityID)
 		if err != nil {
 			return fmt.Errorf("insert event: %w", err)
 		}
@@ -103,16 +88,9 @@ func (b *Bus) ReplayEvent(ctx context.Context, ev *inventory.Event) (int64, erro
 		}
 		eventID = id
 
-		inserted := &inventory.Event{
-			EventID:      eventID,
-			EventType:    ev.EventType,
-			TimestampUTC: ev.TimestampUTC,
-			ActorUserID:  ev.ActorUserID,
-			Payload:      ev.Payload,
-			Note:         ev.Note,
-			EntityID:     ev.EntityID,
-		}
-		return b.applyEventTx(ctx, tx, inserted)
+		inserted := *ev
+		inserted.EventID = eventID
+		return b.applyEventTx(ctx, tx, &inserted)
 	})
 	if err != nil {
 		return 0, err

--- a/internal/eventbus/bus_test.go
+++ b/internal/eventbus/bus_test.go
@@ -33,3 +33,101 @@ func TestDispatch_UnknownEventType(t *testing.T) {
 	_, err := b.Dispatch(context.Background(), inventory.EventType(999), "alice", payload, nil)
 	assert.Error(t, err)
 }
+
+func mustMarshal(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}
+
+func TestReplayEvent_ReturnsNewDBAssignedID(t *testing.T) {
+	s := openTestStore(t)
+	b := eventbus.New(s)
+	ctx := context.Background()
+
+	payload := mustMarshal(t, eventbus.EntityCreatedPayload{
+		EntityID: "r1", DisplayName: "Replay Room", EntityType: "place",
+	})
+	ev := &inventory.Event{
+		EventType:    inventory.EntityCreatedEvent,
+		TimestampUTC: "2020-01-01T00:00:00Z",
+		ActorUserID:  "alice",
+		Payload:      payload,
+	}
+
+	id, err := b.ReplayEvent(ctx, ev)
+	require.NoError(t, err)
+	assert.Positive(t, id)
+}
+
+func TestReplayEvent_PreservesOriginalTimestamp(t *testing.T) {
+	s := openTestStore(t)
+	b := eventbus.New(s)
+	ctx := context.Background()
+
+	const originalTS = "2020-06-15T12:00:00Z"
+	payload := mustMarshal(t, eventbus.EntityCreatedPayload{
+		EntityID: "r2", DisplayName: "Time Capsule", EntityType: "place",
+	})
+	ev := &inventory.Event{
+		EventType:    inventory.EntityCreatedEvent,
+		TimestampUTC: originalTS,
+		ActorUserID:  "alice",
+		Payload:      payload,
+	}
+
+	id, err := b.ReplayEvent(ctx, ev)
+	require.NoError(t, err)
+
+	stored, err := s.GetEventByID(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, originalTS, stored.TimestampUTC)
+}
+
+func TestReplayEvent_PathChangedEvent_IsNoOp(t *testing.T) {
+	s := openTestStore(t)
+	b := eventbus.New(s)
+	ctx := context.Background()
+
+	payload := mustMarshal(t, eventbus.EntityPathChangedPayload{
+		EntityID: "p99", FullPathDisplay: "Ghost:Path", FullPathCanonical: "ghost:path", Depth: 2,
+	})
+	ev := &inventory.Event{
+		EventType:    inventory.EntityPathChangedEvent,
+		TimestampUTC: "2021-03-01T00:00:00Z",
+		ActorUserID:  "system",
+		Payload:      payload,
+	}
+
+	id, err := b.ReplayEvent(ctx, ev)
+	require.NoError(t, err)
+	assert.Zero(t, id, "path-changed replay should return 0 (no row inserted)")
+
+	// Confirm nothing was written
+	_, err = s.GetEventByID(ctx, 1)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestReplayEvent_NonPathChangedEvent_AppliesProjection(t *testing.T) {
+	s := openTestStore(t)
+	b := eventbus.New(s)
+	ctx := context.Background()
+
+	payload := mustMarshal(t, eventbus.EntityCreatedPayload{
+		EntityID: "r3", DisplayName: "Projected Room", EntityType: "place",
+	})
+	ev := &inventory.Event{
+		EventType:    inventory.EntityCreatedEvent,
+		TimestampUTC: "2022-09-10T08:00:00Z",
+		ActorUserID:  "bob",
+		Payload:      payload,
+	}
+
+	_, err := b.ReplayEvent(ctx, ev)
+	require.NoError(t, err)
+
+	entity, err := s.GetEntity(ctx, "r3")
+	require.NoError(t, err)
+	assert.Equal(t, "Projected Room", entity.DisplayName)
+}

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -100,6 +100,29 @@ func (s *Store) GetEventsAfter(ctx context.Context, afterID int64) ([]*inventory
 	return scanEvents(rows)
 }
 
+// HasEvents reports whether the events table contains at least one row.
+func (s *Store) HasEvents(ctx context.Context) (bool, error) {
+	var exists bool
+	const query = `SELECT EXISTS(SELECT 1 FROM events LIMIT 1)`
+	if err := s.db.QueryRowContext(ctx, query).Scan(&exists); err != nil {
+		return false, fmt.Errorf("has events: %w", err)
+	}
+	return exists, nil
+}
+
+// ClearAllData deletes all rows from entities_current then events, leaving schema_metadata intact.
+func (s *Store) ClearAllData(ctx context.Context) error {
+	return s.ExecInTransaction(ctx, func(tx Tx) error {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM entities_current`); err != nil {
+			return fmt.Errorf("clear entities: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM events`); err != nil {
+			return fmt.Errorf("clear events: %w", err)
+		}
+		return nil
+	})
+}
+
 func scanEvent(row *sql.Row) (*inventory.Event, error) {
 	var ev inventory.Event
 	var payloadStr string

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -110,7 +110,14 @@ func (s *Store) HasEvents(ctx context.Context) (bool, error) {
 	return exists, nil
 }
 
-// ClearAllData deletes all rows from entities_current then events, leaving schema_metadata intact.
+// ClearAllData deletes all rows from entities_current then events, leaving
+// schema_metadata intact.
+//
+// INVARIANT: entities_current is the only projection table (see CONTEXT.md
+// "Projection"). If a second projection table is ever added, it must also be
+// cleared here AND that change should be captured in an ADR — adding a
+// projection breaks the documented single-projection invariant and the
+// decision deserves to be recorded before the code is changed.
 func (s *Store) ClearAllData(ctx context.Context) error {
 	return s.ExecInTransaction(ctx, func(tx Tx) error {
 		if _, err := tx.ExecContext(ctx, `DELETE FROM entities_current`); err != nil {

--- a/internal/store/events_test.go
+++ b/internal/store/events_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/asphaltbuffet/wherehouse/internal/inventory"
+	"github.com/asphaltbuffet/wherehouse/internal/store"
 )
 
 func TestAppendRawEvent(t *testing.T) {
@@ -50,4 +51,61 @@ func TestGetEventsByEntity(t *testing.T) {
 	events, err := s.GetEventsByEntity(ctx, entityID)
 	require.NoError(t, err)
 	assert.Len(t, events, 1)
+}
+
+func TestHasEvents_EmptyDatabase(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	has, err := s.HasEvents(ctx)
+	require.NoError(t, err)
+	assert.False(t, has)
+}
+
+func TestHasEvents_AfterInsert(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	payload := json.RawMessage(`{"entity_id":"x1","display_name":"Box","entity_type":"place"}`)
+	entityID := "x1"
+	_, err := s.AppendRawEvent(ctx, inventory.EntityCreatedEvent, "alice", payload, nil, &entityID)
+	require.NoError(t, err)
+
+	has, err := s.HasEvents(ctx)
+	require.NoError(t, err)
+	assert.True(t, has)
+}
+
+func TestClearAllData_RemovesEventsAndEntities(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	// Seed an event and an entity projection
+	payload := json.RawMessage(`{"entity_id":"c1","display_name":"Shelf","entity_type":"place"}`)
+	entityID := "c1"
+	_, err := s.AppendRawEvent(ctx, inventory.EntityCreatedEvent, "alice", payload, nil, &entityID)
+	require.NoError(t, err)
+
+	err = s.ClearAllData(ctx)
+	require.NoError(t, err)
+
+	has, err := s.HasEvents(ctx)
+	require.NoError(t, err)
+	assert.False(t, has, "events table should be empty after ClearAllData")
+
+	_, err = s.GetEntity(ctx, "c1")
+	assert.ErrorIs(t, err, store.ErrNotFound, "entities_current should be empty after ClearAllData")
+}
+
+func TestClearAllData_PreservesSchemaMetadata(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	err := s.ClearAllData(ctx)
+	require.NoError(t, err)
+
+	// schema_metadata is seeded by the migration with "created_at" and "app_version"
+	val, err := s.GetMetadata(ctx, "app_version")
+	require.NoError(t, err)
+	assert.NotEmpty(t, val, "schema_metadata should survive ClearAllData")
 }


### PR DESCRIPTION
This pull request introduces a new `import` command for the CLI, enabling users to restore inventory state by importing events from an NDJSON file. The implementation includes robust input handling, user safety checks for destructive operations, and a comprehensive suite of tests. It also updates documentation to clarify the import process and warning handling.

**Major features and changes:**

### New Import Command Implementation

* Added a new `import` command (`cmd/import/import.go`, `cmd/import/db.go`) that reads events from an NDJSON file or stdin and replays them into the database, with options for replacing existing data, continuing on errors, and detailed summary output. [[1]](diffhunk://#diff-4c66f315bda0824d6ab8baed58c8b7d20c3cf207624a96757c11f7b0f34b73f6R1-R155) [[2]](diffhunk://#diff-6473a7424d116946f5cf4237db3470e0a1021c912c91b80aecb54e87eb940d74R1-R14)
* Integrated the new import command into the CLI by registering it in `cmd/root.go`. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR15) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR72)

### Robust Input and Error Handling

* Enforced a per-line input size limit of 16 MiB to prevent garbage/binary files from causing issues, with documentation added to `CONTEXT.md` explaining the rationale. [[1]](diffhunk://#diff-4c66f315bda0824d6ab8baed58c8b7d20c3cf207624a96757c11f7b0f34b73f6R1-R155) [[2]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14R43-R46)
* Implemented safety checks requiring `--yes` confirmation for destructive `--replace` operations and preventing import if the database is non-empty unless explicitly replaced.

### Comprehensive Testing

* Added a thorough test suite for the import command (`cmd/import/import_test.go`), covering valid/invalid input, error handling, quiet mode, large event notes, warning surfaces, and destructive operation safeguards.

### Documentation Updates

* Clarified the import process, including the use of a shared `writeEvent` helper and the handling of warnings in `ImportResult`, in the ADR documentation. [[1]](diffhunk://#diff-d75af6086bc0cfa05d05eef96027d7d3d83b2ad1194ecf3976fd3cece31c3f48R8-R16) [[2]](diffhunk://#diff-c9b52e52f75f25f07bbbf8cbf7e6c406f061acff87f8c3875cd97abe992a48a8L7-R16)

---

**References:**  
[[1]](diffhunk://#diff-4c66f315bda0824d6ab8baed58c8b7d20c3cf207624a96757c11f7b0f34b73f6R1-R155) [[2]](diffhunk://#diff-6473a7424d116946f5cf4237db3470e0a1021c912c91b80aecb54e87eb940d74R1-R14) [[3]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR15) [[4]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR72) [[5]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14R43-R46) [[6]](diffhunk://#diff-c35e0574da65a9552f3d3e5205edc540b7aa51444044d4a277ede73172872000R1-R338) [[7]](diffhunk://#diff-d75af6086bc0cfa05d05eef96027d7d3d83b2ad1194ecf3976fd3cece31c3f48R8-R16) [[8]](diffhunk://#diff-c9b52e52f75f25f07bbbf8cbf7e6c406f061acff87f8c3875cd97abe992a48a8L7-R16)