### PR TITLE
Fix event bus and import validation for path changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.5.1] - 2026-05-31
+
+### Fixed
+
+- Fix duplication of entity path changed events during imports
+
 ## [0.5.0] - 2026-05-30
 
 ### Added
@@ -105,6 +111,7 @@ _First release._
 - Use NanoID instead of UUID for item identifiers (shorter, more readable) ([`4772974`](https://github.com/asphaltbuffet/wherehouse/commit/4772974))
 - Unify output styling across all commands ([`0e24808`](https://github.com/asphaltbuffet/wherehouse/commit/0e24808))
 
+[0.5.1]: https://github.com/asphaltbuffet/wherehouse/compare/v0.5.1...v0.5.1
 [0.5.0]: https://github.com/asphaltbuffet/wherehouse/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/asphaltbuffet/wherehouse/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/asphaltbuffet/wherehouse/compare/v0.2.0...v0.3.0

--- a/docs/adr/0004-import-replay-event-bus-method.md
+++ b/docs/adr/0004-import-replay-event-bus-method.md
@@ -8,9 +8,11 @@ We added a `Bus.ReplayEvent(ctx, *inventory.Event) (int64, error)` method that a
 
 ## Implementation note: shared writeEvent helper
 
-Both `Dispatch` and `ReplayEvent` now delegate to a private `Bus.writeEvent(ctx, *inventory.Event) (int64, error)` helper that owns the INSERT + `LastInsertId` + `applyEventTx` sequence. The public separation between `Dispatch` and `ReplayEvent` remains because the two paths differ in how they source `TimestampUTC` and `EntityID`:
+Both `Dispatch` and `ReplayEvent` delegate to a private `Bus.writeEvent(ctx, *inventory.Event, applyFn) (int64, error)` helper that owns the INSERT + `LastInsertId` + apply-function sequence. The public separation between `Dispatch` and `ReplayEvent` remains because the two paths differ in how they source `TimestampUTC` and `EntityID`, and in which apply function they use:
 
-- `Dispatch` stamps `time.Now()` and parses `entity_id` from the payload.
-- `ReplayEvent` uses the values already on the supplied `*inventory.Event`.
+- `Dispatch` stamps `time.Now()`, parses `entity_id` from the payload, and calls `applyEventTx` (which writes derived `EntityPathChangedEvent` rows as a side effect).
+- `ReplayEvent` uses the values already on the supplied `*inventory.Event` and passes a closure as the apply function: `EntityReparentedEvent` is routed to `handleEntityReparentedComputePayloadsTx` (updates projection, no event writes, returns computed payloads); all other events go through `applyEventProjectionOnlyTx`.
 
-If a future change needs to differ further between the two paths (for example, one adds a validation step or a side effect the other shouldn't), express it as a parameter to `writeEvent` rather than re-splitting the helper into two implementations. Keeping a single canonical write path is what makes "ReplayEvent and Dispatch produce identical post-conditions" a checkable property instead of a hope.
+## ReplayEvent return signature
+
+`ReplayEvent` returns `(int64, []EntityPathChangedPayload, error)`. The payload slice is non-nil only when the replayed event is an `EntityReparentedEvent`; it carries the expected `EntityPathChangedPayload` for each affected descendant, computed from the post-reparent projection state. The import layer uses these to validate the path-changed records buffered from the export stream without relying on `GetEventsAfter` side effects. See ADR-0005.

--- a/docs/adr/0005-import-skips-derived-path-changed-events.md
+++ b/docs/adr/0005-import-skips-derived-path-changed-events.md
@@ -4,7 +4,9 @@
 
 Replaying path-changed events via `ReplayEvent` during import would corrupt the projection: `handleEntityReparented` already regenerates them, so each descendant's path would be updated twice — once by the reparent handler and once by the explicit path-changed replay.
 
-Instead, import skips `EntityPathChangedEvent` records during replay. The bus regenerates them correctly when each `EntityReparentedEvent` is replayed. The skipped records from the export are not discarded — they are compared against the freshly-generated records (via `store.GetEventsAfter`) to validate export integrity. Count mismatches or payload mismatches are surfaced as warnings on the `ImportResult` and logged via the structured logger. This validation is non-fatal: a warning indicates possible export corruption or schema divergence but does not abort the import.
+Instead, import skips `EntityPathChangedEvent` records during replay. The bus recomputes the correct descendant paths when each `EntityReparentedEvent` is replayed (via `handleEntityReparentedComputePayloadsTx`) and returns the expected `EntityPathChangedPayload` for each affected descendant directly in the `ReplayEvent` return value. The skipped records from the export are not discarded — they are buffered and compared field-by-field against the bus-returned payloads to validate export integrity. Count mismatches or payload mismatches are surfaced as warnings on the `ImportResult` and logged via the structured logger. This validation is non-fatal: a warning indicates possible export corruption or schema divergence but does not abort the import.
+
+No new `EntityPathChangedEvent` rows are written to the event log during import. The event-log-growth defect that existed when `ReplayEvent` used `applyEventTx` (which called `propagatePathChangesTx`) was fixed in #191.
 
 ## Warning surface
 

--- a/docs/adr/0009-projection-rebuild-skips-path-changed-events.md
+++ b/docs/adr/0009-projection-rebuild-skips-path-changed-events.md
@@ -22,4 +22,4 @@ A boolean `writesEvents bool` parameter on `applyEventTx` was considered and rej
 
 ## Relationship to `ReplayEvent` (import)
 
-`ReplayEvent` has the same event-log-growth defect — it also routes `EntityReparentedEvent` through `applyEventTx`. Fixing it requires redesigning the import path-changed validation (see ADR-0005), which currently relies on `GetEventsAfter` side effects to detect export corruption. That work is tracked in issue #191.
+`ReplayEvent` previously had the same event-log-growth defect — it routed `EntityReparentedEvent` through `applyEventTx`, which called `propagatePathChangesTx` and inserted duplicate `EntityPathChangedEvent` rows on every import run. This was fixed in #191: `ReplayEvent` now uses a closure that routes `EntityReparentedEvent` through `handleEntityReparentedComputePayloadsTx` (updates the projection, no event writes) and all other events through `applyEventProjectionOnlyTx`. The import path-changed validation no longer relies on `GetEventsAfter` side effects; see ADR-0005.

--- a/internal/app/import.go
+++ b/internal/app/import.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/asphaltbuffet/wherehouse/internal/eventbus"
 	"github.com/asphaltbuffet/wherehouse/internal/inventory"
 	"github.com/asphaltbuffet/wherehouse/internal/logging"
 )
@@ -31,13 +32,12 @@ type ImportResult struct {
 }
 
 type importBus interface {
-	ReplayEvent(ctx context.Context, ev *inventory.Event) (int64, error)
+	ReplayEvent(ctx context.Context, ev *inventory.Event) (int64, []eventbus.EntityPathChangedPayload, error)
 }
 
 type importStore interface {
 	HasEvents(ctx context.Context) (bool, error)
 	ClearAllData(ctx context.Context) error
-	GetEventsAfter(ctx context.Context, afterID int64) ([]*inventory.Event, error)
 }
 
 // ImportEvents replays a slice of ExportResult records into the database.
@@ -104,24 +104,34 @@ func importEvents(
 		}
 	}
 
-	r := &importRunner{bus: bus, store: store, log: logging.GetLogger(), opts: opts, pendingReparentID: -1}
+	r := &importRunner{bus: bus, store: store, log: logging.GetLogger(), opts: opts}
 	for _, rec := range events {
 		if err := r.processRecord(ctx, rec); err != nil {
 			return r.result, err
 		}
 	}
-	r.flushValidation(ctx)
+	r.flushValidation()
 	return r.result, nil
 }
 
 type importRunner struct {
-	bus               importBus
-	store             importStore
-	log               logging.Logger
-	opts              ImportOptions
-	result            ImportResult
-	pendingReparentID int64
-	pathChangedBuf    []ExportResult
+	bus    importBus
+	store  importStore
+	log    logging.Logger
+	opts   ImportOptions
+	result ImportResult
+
+	// pendingReparent is set when an EntityReparentedEvent has been replayed
+	// but its buffered EntityPathChangedEvent records have not yet been
+	// validated. Nil means no reparent is in flight.
+	pendingReparent *pendingReparentState
+	pathChangedBuf  []ExportResult
+}
+
+type pendingReparentState struct {
+	eventID  int64
+	entityID *string
+	payloads []eventbus.EntityPathChangedPayload
 }
 
 func (r *importRunner) processRecord(ctx context.Context, rec ExportResult) error {
@@ -131,7 +141,7 @@ func (r *importRunner) processRecord(ctx context.Context, rec ExportResult) erro
 	}
 
 	if et == inventory.EntityPathChangedEvent {
-		if r.pendingReparentID < 0 {
+		if r.pendingReparent == nil {
 			orphan := fmt.Errorf("orphaned EntityPathChangedEvent at event_id %d (no preceding reparent)", rec.EventID)
 			r.log.Warn(orphan.Error())
 			r.warn(orphan)
@@ -141,7 +151,7 @@ func (r *importRunner) processRecord(ctx context.Context, rec ExportResult) erro
 		return nil
 	}
 
-	r.flushValidation(ctx)
+	r.flushValidation()
 
 	ev := &inventory.Event{
 		EventType:    et,
@@ -152,14 +162,18 @@ func (r *importRunner) processRecord(ctx context.Context, rec ExportResult) erro
 		EntityID:     rec.EntityID,
 	}
 
-	newID, replayErr := r.bus.ReplayEvent(ctx, ev)
+	newID, payloads, replayErr := r.bus.ReplayEvent(ctx, ev)
 	if replayErr != nil {
 		return r.handleError(rec.EventID, replayErr)
 	}
 	r.result.Replayed++
 
 	if et == inventory.EntityReparentedEvent {
-		r.pendingReparentID = newID
+		r.pendingReparent = &pendingReparentState{
+			eventID:  newID,
+			entityID: rec.EntityID,
+			payloads: payloads,
+		}
 	}
 	return nil
 }
@@ -181,47 +195,44 @@ func (r *importRunner) handleError(eventID int64, err error) error {
 	return wrapped
 }
 
-func (r *importRunner) flushValidation(ctx context.Context) {
-	if r.pendingReparentID < 0 {
+func (r *importRunner) flushValidation() {
+	if r.pendingReparent == nil {
 		return
 	}
-	generated, err := r.store.GetEventsAfter(ctx, r.pendingReparentID)
-	if err != nil {
-		wrapped := fmt.Errorf(
-			"could not retrieve generated path-changed events after reparent event_id %d: %w",
-			r.pendingReparentID,
-			err,
-		)
-		r.log.Warn(wrapped.Error())
-		r.warn(wrapped)
-		r.pendingReparentID = -1
-		r.pathChangedBuf = nil
+	pr := r.pendingReparent
+	r.pendingReparent = nil
+
+	computed := pr.payloads
+	buf := r.pathChangedBuf
+	r.pathChangedBuf = nil
+
+	if len(computed) != len(buf) {
+		mismatch := fmt.Errorf("path-changed count mismatch after reparent event_id %d (expected %d, got %d)",
+			pr.eventID, len(buf), len(computed))
+		r.log.Warn(mismatch.Error())
+		r.warn(mismatch)
 		return
 	}
-	var genPC []*inventory.Event
-	for _, ev := range generated {
-		if ev.EventType == inventory.EntityPathChangedEvent {
-			genPC = append(genPC, ev)
-		} else {
+
+	for i, bufRec := range buf {
+		var imported eventbus.EntityPathChangedPayload
+		if err := json.Unmarshal(bufRec.Payload, &imported); err != nil {
+			mismatch := fmt.Errorf("path-changed payload parse error after reparent event_id %d at index %d: %w",
+				pr.eventID, i, err)
+			r.log.Warn(mismatch.Error())
+			r.warn(mismatch)
+			break
+		}
+		c := computed[i]
+		if imported.EntityID != c.EntityID ||
+			imported.FullPathDisplay != c.FullPathDisplay ||
+			imported.FullPathCanonical != c.FullPathCanonical ||
+			imported.Depth != c.Depth {
+			mismatch := fmt.Errorf("path-changed payload mismatch after reparent event_id %d at index %d",
+				pr.eventID, i)
+			r.log.Warn(mismatch.Error())
+			r.warn(mismatch)
 			break
 		}
 	}
-	if len(genPC) != len(r.pathChangedBuf) {
-		mismatch := fmt.Errorf("path-changed count mismatch after reparent event_id %d (expected %d, got %d)",
-			r.pendingReparentID, len(r.pathChangedBuf), len(genPC))
-		r.log.Warn(mismatch.Error())
-		r.warn(mismatch)
-	} else {
-		for i, buf := range r.pathChangedBuf {
-			if string(genPC[i].Payload) != string(buf.Payload) {
-				mismatch := fmt.Errorf("path-changed payload mismatch after reparent event_id %d at index %d",
-					r.pendingReparentID, i)
-				r.log.Warn(mismatch.Error())
-				r.warn(mismatch)
-				break
-			}
-		}
-	}
-	r.pendingReparentID = -1
-	r.pathChangedBuf = nil
 }

--- a/internal/eventbus/bus.go
+++ b/internal/eventbus/bus.go
@@ -62,11 +62,20 @@ func (b *Bus) Dispatch(
 // error and returns 0 — the import path omits these from replay and validates
 // them separately (see ADR-0005). See also: the event-log-growth issue filed
 // against this behaviour.
-func (b *Bus) ReplayEvent(ctx context.Context, ev *inventory.Event) (int64, error) {
+func (b *Bus) ReplayEvent(ctx context.Context, ev *inventory.Event) (int64, []EntityPathChangedPayload, error) {
 	if ev.EventType == inventory.EntityPathChangedEvent {
-		return 0, nil
+		return 0, nil, nil
 	}
-	return b.writeEvent(ctx, ev, b.applyEventTx)
+	var payloads []EntityPathChangedPayload
+	id, err := b.writeEvent(ctx, ev, func(ctx context.Context, tx store.Tx, ev *inventory.Event) error {
+		if ev.EventType == inventory.EntityReparentedEvent {
+			var applyErr error
+			payloads, applyErr = b.handleEntityReparentedComputePayloadsTx(ctx, tx, ev)
+			return applyErr
+		}
+		return b.applyEventProjectionOnlyTx(ctx, tx, ev)
+	})
+	return id, payloads, err
 }
 
 // writeEvent is the single canonical write path shared by Dispatch and

--- a/internal/eventbus/bus_test.go
+++ b/internal/eventbus/bus_test.go
@@ -56,7 +56,7 @@ func TestReplayEvent_ReturnsNewDBAssignedID(t *testing.T) {
 		Payload:      payload,
 	}
 
-	id, err := b.ReplayEvent(ctx, ev)
+	id, _, err := b.ReplayEvent(ctx, ev)
 	require.NoError(t, err)
 	assert.Positive(t, id)
 }
@@ -77,7 +77,7 @@ func TestReplayEvent_PreservesOriginalTimestamp(t *testing.T) {
 		Payload:      payload,
 	}
 
-	id, err := b.ReplayEvent(ctx, ev)
+	id, _, err := b.ReplayEvent(ctx, ev)
 	require.NoError(t, err)
 
 	stored, err := s.GetEventByID(ctx, id)
@@ -100,7 +100,7 @@ func TestReplayEvent_PathChangedEvent_IsNoOp(t *testing.T) {
 		Payload:      payload,
 	}
 
-	id, err := b.ReplayEvent(ctx, ev)
+	id, _, err := b.ReplayEvent(ctx, ev)
 	require.NoError(t, err)
 	assert.Zero(t, id, "path-changed replay should return 0 (no row inserted)")
 
@@ -124,7 +124,7 @@ func TestReplayEvent_NonPathChangedEvent_AppliesProjection(t *testing.T) {
 		Payload:      payload,
 	}
 
-	_, err := b.ReplayEvent(ctx, ev)
+	_, _, err := b.ReplayEvent(ctx, ev)
 	require.NoError(t, err)
 
 	entity, err := s.GetEntity(ctx, "r3")

--- a/internal/eventbus/handlers.go
+++ b/internal/eventbus/handlers.go
@@ -172,6 +172,60 @@ func (b *Bus) handleEntityReparentedProjectionOnlyTx(ctx context.Context, tx sto
 	return nil
 }
 
+// handleEntityReparentedComputePayloadsTx updates the projection for the
+// reparented entity and all its descendants (no event writes) and returns the
+// expected EntityPathChangedPayload for each descendant. Used by ReplayEvent
+// so import can validate export integrity without side-effect event insertion.
+func (b *Bus) handleEntityReparentedComputePayloadsTx(ctx context.Context, tx store.Tx, ev *inventory.Event) ([]EntityPathChangedPayload, error) {
+	var p EntityReparentedPayload
+	if err := json.Unmarshal(ev.Payload, &p); err != nil {
+		return nil, fmt.Errorf("handleEntityReparentedComputePayloadsTx: unmarshal: %w", err)
+	}
+
+	// Fetch descendants before updating the parent so the path-prefix query
+	// still matches the old canonical path stored in the DB.
+	descendants, err := b.store.GetDescendantsTx(ctx, tx, p.EntityID)
+	if err != nil {
+		return nil, fmt.Errorf("handleEntityReparentedComputePayloadsTx: get descendants: %w", err)
+	}
+
+	entity, err := b.store.GetEntityTx(ctx, tx, p.EntityID)
+	if err != nil {
+		return nil, fmt.Errorf("handleEntityReparentedComputePayloadsTx: get entity: %w", err)
+	}
+
+	entity.ParentID = p.NewParentID
+	entity.FullPathDisplay, entity.FullPathCanonical, entity.Depth, err = b.store.ComputeEntityPathTx(
+		ctx, tx, entity.DisplayName, entity.CanonicalName, entity.ParentID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("handleEntityReparentedComputePayloadsTx: recompute path: %w", err)
+	}
+
+	entity.LastEventID = ev.EventID
+	entity.UpdatedAt = time.Now().UTC()
+
+	if err = b.store.UpdateEntityTx(ctx, tx, entity); err != nil {
+		return nil, fmt.Errorf("handleEntityReparentedComputePayloadsTx: update entity: %w", err)
+	}
+
+	payloads := ComputeDescendantPathPayloads(entity, descendants)
+
+	for i, d := range descendants {
+		dp := payloads[i]
+		d.FullPathDisplay = dp.FullPathDisplay
+		d.FullPathCanonical = dp.FullPathCanonical
+		d.Depth = dp.Depth
+		d.LastEventID = ev.EventID
+		d.UpdatedAt = time.Now().UTC()
+		if err = b.store.UpdateEntityTx(ctx, tx, d); err != nil {
+			return nil, fmt.Errorf("handleEntityReparentedComputePayloadsTx: update descendant %s: %w", d.EntityID, err)
+		}
+	}
+
+	return payloads, nil
+}
+
 func (b *Bus) handleEntityPathChanged(ctx context.Context, tx store.Tx, ev *inventory.Event) error {
 	var p EntityPathChangedPayload
 	if err := json.Unmarshal(ev.Payload, &p); err != nil {
@@ -249,34 +303,17 @@ func (b *Bus) propagatePathChangesTx(
 	parent *inventory.Entity,
 	descendants []*inventory.Entity,
 ) error {
-	updated := map[string]*inventory.Entity{parent.EntityID: parent}
+	payloads := ComputeDescendantPathPayloads(parent, descendants)
 
-	for _, d := range descendants {
-		var parentDisplay, parentCanonical string
-		var parentDepth int
-		if d.ParentID != nil {
-			p, ok := updated[*d.ParentID]
-			if !ok {
-				return fmt.Errorf("propagatePathChangesTx: parent %s of %s not in updated set", *d.ParentID, d.EntityID)
-			}
-			parentDisplay = p.FullPathDisplay
-			parentCanonical = p.FullPathCanonical
-			parentDepth = p.Depth
-		}
-
-		d.FullPathDisplay = parentDisplay + ":" + d.DisplayName
-		d.FullPathCanonical = parentCanonical + ":" + d.CanonicalName
-		d.Depth = parentDepth + 1
+	for i, d := range descendants {
+		p := payloads[i]
+		d.FullPathDisplay = p.FullPathDisplay
+		d.FullPathCanonical = p.FullPathCanonical
+		d.Depth = p.Depth
 		d.LastEventID = triggeringEv.EventID
 		d.UpdatedAt = time.Now().UTC()
 
-		payload := EntityPathChangedPayload{
-			EntityID:          d.EntityID,
-			FullPathDisplay:   d.FullPathDisplay,
-			FullPathCanonical: d.FullPathCanonical,
-			Depth:             d.Depth,
-		}
-		payloadJSON, err := json.Marshal(payload)
+		payloadJSON, err := json.Marshal(p)
 		if err != nil {
 			return fmt.Errorf("marshal path_changed payload for %s: %w", d.EntityID, err)
 		}
@@ -298,9 +335,43 @@ func (b *Bus) propagatePathChangesTx(
 		if err = b.store.UpdateEntityTx(ctx, tx, d); err != nil {
 			return fmt.Errorf("update descendant %s: %w", d.EntityID, err)
 		}
-
-		updated[d.EntityID] = d
 	}
 
 	return nil
+}
+
+// ComputeDescendantPathPayloads computes the new EntityPathChangedPayload for
+// each descendant given the already-updated parent. Descendants must be ordered
+// parent-before-child (depth ASC). No DB access; safe to call outside a
+// transaction.
+func ComputeDescendantPathPayloads(parent *inventory.Entity, descendants []*inventory.Entity) []EntityPathChangedPayload {
+	updated := map[string]*inventory.Entity{parent.EntityID: parent}
+	payloads := make([]EntityPathChangedPayload, len(descendants))
+
+	for i, d := range descendants {
+		var parentDisplay, parentCanonical string
+		var parentDepth int
+		if d.ParentID != nil {
+			if p, ok := updated[*d.ParentID]; ok {
+				parentDisplay = p.FullPathDisplay
+				parentCanonical = p.FullPathCanonical
+				parentDepth = p.Depth
+			}
+		}
+
+		computed := *d
+		computed.FullPathDisplay = parentDisplay + ":" + d.DisplayName
+		computed.FullPathCanonical = parentCanonical + ":" + d.CanonicalName
+		computed.Depth = parentDepth + 1
+
+		payloads[i] = EntityPathChangedPayload{
+			EntityID:          d.EntityID,
+			FullPathDisplay:   computed.FullPathDisplay,
+			FullPathCanonical: computed.FullPathCanonical,
+			Depth:             computed.Depth,
+		}
+		updated[d.EntityID] = &computed
+	}
+
+	return payloads
 }

--- a/internal/eventbus/handlers.go
+++ b/internal/eventbus/handlers.go
@@ -176,7 +176,11 @@ func (b *Bus) handleEntityReparentedProjectionOnlyTx(ctx context.Context, tx sto
 // reparented entity and all its descendants (no event writes) and returns the
 // expected EntityPathChangedPayload for each descendant. Used by ReplayEvent
 // so import can validate export integrity without side-effect event insertion.
-func (b *Bus) handleEntityReparentedComputePayloadsTx(ctx context.Context, tx store.Tx, ev *inventory.Event) ([]EntityPathChangedPayload, error) {
+func (b *Bus) handleEntityReparentedComputePayloadsTx(
+	ctx context.Context,
+	tx store.Tx,
+	ev *inventory.Event,
+) ([]EntityPathChangedPayload, error) {
 	var p EntityReparentedPayload
 	if err := json.Unmarshal(ev.Payload, &p); err != nil {
 		return nil, fmt.Errorf("handleEntityReparentedComputePayloadsTx: unmarshal: %w", err)
@@ -344,7 +348,10 @@ func (b *Bus) propagatePathChangesTx(
 // each descendant given the already-updated parent. Descendants must be ordered
 // parent-before-child (depth ASC). No DB access; safe to call outside a
 // transaction.
-func ComputeDescendantPathPayloads(parent *inventory.Entity, descendants []*inventory.Entity) []EntityPathChangedPayload {
+func ComputeDescendantPathPayloads(
+	parent *inventory.Entity,
+	descendants []*inventory.Entity,
+) []EntityPathChangedPayload {
 	updated := map[string]*inventory.Entity{parent.EntityID: parent}
 	payloads := make([]EntityPathChangedPayload, len(descendants))
 

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -87,19 +87,6 @@ func (s *Store) GetAllEvents(ctx context.Context) ([]*inventory.Event, error) {
 	return scanEvents(rows)
 }
 
-// GetEventsAfter retrieves events with event_id > afterID, ordered by event_id ASC.
-func (s *Store) GetEventsAfter(ctx context.Context, afterID int64) ([]*inventory.Event, error) {
-	const query = `
-		SELECT event_id, event_type, timestamp_utc, actor_user_id, payload, note, entity_id
-		FROM events WHERE event_id > ? ORDER BY event_id ASC`
-	rows, err := s.db.QueryContext(ctx, query, afterID)
-	if err != nil {
-		return nil, fmt.Errorf("query events after %d: %w", afterID, err)
-	}
-	defer rows.Close()
-	return scanEvents(rows)
-}
-
 // HasEvents reports whether the events table contains at least one row.
 func (s *Store) HasEvents(ctx context.Context) (bool, error) {
 	var exists bool

--- a/mise.toml
+++ b/mise.toml
@@ -138,5 +138,5 @@ sources = ["**/*.go", "**/testdata/**"]
 outputs = ["bin/coverage.out"]
 run = [
   "mkdir -p bin",
-  "gotestsum -- -race -covermode=atomic -coverprofile=bin/coverage.out $(go list ./... | grep -v /mocks | grep -v /ai-docs)",
+  "gotestsum -- -race -covermode=atomic -coverprofile=bin/coverage.out $(go list ./... | grep -v /mocks)",
 ]


### PR DESCRIPTION
## Summary

<!-- What does this change do and why? -->

## Checklist

### Every PR

- [x] `mise run lint` passes
- [x] `mise run test` passes
- [x] New or changed behavior has test coverage

### If this PR should trigger a release

- [ ] Ran `mise run release <major|minor|patch>` (updates `VERSION` and README nix pins)
- [ ] `CHANGELOG.md` has an entry for the new version (`## [x.y.z] - YYYY-MM-DD`)
- [ ] `VERSION`, `CHANGELOG.md`, and `README.md` are all updated in this PR

### If this PR adds a new event type

- [ ] Added to `EventType` iota + `eventTypeByName` map in `internal/inventory/event_type.go`
- [ ] Ran `go generate ./...` to regenerate `eventtype_string.go`
- [ ] Added case to `applyEventTx` in `internal/eventbus/bus.go`
- [ ] Added payload struct to `internal/eventbus/payloads.go`
- [ ] Added entry to `payloadPrototypes` in `internal/app/doctor.go`

### If this PR adds a new CLI command

- [ ] `NewXxxCmd(db xxxDB)` and `NewDefaultXxxCmd()` constructors present
- [ ] Per-command `xxxDB` interface defined in `cmd/xxx/db.go`
- [ ] Registered in `cmd/root.go` via `NewDefaultXxxCmd()`
- [ ] `--json` flag present
