### PR TITLE
fix: align config check output to [kind] description convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.5.1] - 2026-05-31
 
+### Changed
+
+- Matched config check issues output format with doctor issues
+
 ### Fixed
 
 - Fix duplication of entity path changed events during imports

--- a/cmd/config/check.go
+++ b/cmd/config/check.go
@@ -62,8 +62,7 @@ func runCheck(cmd *cobra.Command, _ []string) error {
 	if globalExists {
 		err = config.Check(cmdFS, expandedGlobal)
 		if err != nil {
-			out.Error(fmt.Sprintf("Configuration invalid: %s", expandedGlobal))
-			out.Println(fmt.Sprintf("  Error: %v", err))
+			out.Issue("config", fmt.Sprintf("Configuration invalid: %s — %v", expandedGlobal, err))
 			hasErrors = true
 		} else {
 			out.Success(fmt.Sprintf("Global config valid: %s", expandedGlobal))
@@ -79,8 +78,7 @@ func runCheck(cmd *cobra.Command, _ []string) error {
 	if localExists {
 		err = config.Check(cmdFS, expandedLocal)
 		if err != nil {
-			out.Error(fmt.Sprintf("Configuration invalid: %s", expandedLocal))
-			out.Println(fmt.Sprintf("  Error: %v", err))
+			out.Issue("config", fmt.Sprintf("Configuration invalid: %s — %v", expandedLocal, err))
 			hasErrors = true
 		} else {
 			out.Success(fmt.Sprintf("Local config valid: %s", expandedLocal))


### PR DESCRIPTION
Migrate runCheck validation failures from the two-call out.Error+out.Println pattern to out.Issue("config", ...), producing:

  [config] Configuration invalid: /path — parsing config file: ...

ExpandPath and afero.Exists failures remain as out.Error (OS-level, not config validation findings).

Closes #192

## Summary

<!-- What does this change do and why? -->

## Checklist

### Every PR

- [x] `mise run lint` passes
- [x] `mise run test` passes
- [x] New or changed behavior has test coverage

### If this PR should trigger a release

- [ ] Ran `mise run release <major|minor|patch>` (updates `VERSION` and README nix pins)
- [ ] `CHANGELOG.md` has an entry for the new version (`## [x.y.z] - YYYY-MM-DD`)
- [ ] `VERSION`, `CHANGELOG.md`, and `README.md` are all updated in this PR

### If this PR adds a new event type

- [ ] Added to `EventType` iota + `eventTypeByName` map in `internal/inventory/event_type.go`
- [ ] Ran `go generate ./...` to regenerate `eventtype_string.go`
- [ ] Added case to `applyEventTx` in `internal/eventbus/bus.go`
- [ ] Added payload struct to `internal/eventbus/payloads.go`
- [ ] Added entry to `payloadPrototypes` in `internal/app/doctor.go`

### If this PR adds a new CLI command

- [ ] `NewXxxCmd(db xxxDB)` and `NewDefaultXxxCmd()` constructors present
- [ ] Per-command `xxxDB` interface defined in `cmd/xxx/db.go`
- [ ] Registered in `cmd/root.go` via `NewDefaultXxxCmd()`
- [ ] `--json` flag present
